### PR TITLE
Refactor calibration formula implementation

### DIFF
--- a/camp/apps/monitors/admin.py
+++ b/camp/apps/monitors/admin.py
@@ -12,10 +12,10 @@ from .models import Entry
 
 
 class MonitorAdmin(admin.OSMGeoAdmin):
-    list_display = ['name', 'county', 'is_sjvair', 'is_hidden', 'last_updated', 'pm25_calibration_formula']
-    list_editable = ['is_sjvair', 'is_hidden', 'pm25_calibration_formula']
+    list_display = ['name', 'county', 'is_sjvair', 'is_hidden', 'last_updated']
+    list_editable = ['is_sjvair', 'is_hidden']
     list_filter = ['is_sjvair', 'is_hidden', 'county']
-    fields = ['name', 'county', 'is_hidden', 'is_sjvair', 'location', 'position', 'pm25_calibration_formula']
+    fields = ['name', 'county', 'is_hidden', 'is_sjvair', 'location', 'position']
 
     change_form_template = 'admin/monitors/change_form.html'
 

--- a/camp/apps/monitors/models.py
+++ b/camp/apps/monitors/models.py
@@ -80,6 +80,9 @@ class Monitor(models.Model):
         cutoff = timedelta(seconds=self.LAST_ACTIVE_LIMIT)
         return (now - parse_datetime(self.latest['timestamp'])) < cutoff
 
+    def get_pm25_calibration_formula(self):
+        return self.pm25_calibration_formula
+
     def create_entry(self, payload, sensor=None):
         return Entry(
             monitor=self,
@@ -91,7 +94,7 @@ class Monitor(models.Model):
         )
 
     def process_entry(self, entry):
-        entry.calibrate_pm25(self.pm25_calibration_formula)
+        entry.calibrate_pm25(self.get_pm25_calibration_formula())
         entry.calculate_aqi()
         entry.calculate_averages()
         entry.is_processed = True

--- a/camp/apps/monitors/purpleair/admin.py
+++ b/camp/apps/monitors/purpleair/admin.py
@@ -1,3 +1,4 @@
+from django.contrib.admin.options import csrf_protect_m
 from django.contrib.gis import admin
 from django.contrib.humanize.templatetags.humanize import intcomma
 from django.template.defaultfilters import floatformat
@@ -6,6 +7,7 @@ from camp.apps.monitors.admin import MonitorAdmin
 from camp.apps.monitors.purpleair.forms import PurpleAirAddForm
 from camp.apps.monitors.purpleair.models import PurpleAir
 from camp.apps.monitors.purpleair.tasks import import_monitor_data
+from camp.apps.monitors.purpleair.utils import COUNTY_CALIBRATIONS
 from camp.utils.forms import DateRangeForm
 
 
@@ -42,6 +44,13 @@ class PurpleAirAdmin(MonitorAdmin):
             defaults['form'] = self.add_form
         defaults.update(kwargs)
         return super().get_form(request, obj, **defaults)
+
+    @csrf_protect_m
+    def changelist_view(self, request, extra_context=None):
+        if extra_context is None:
+            extra_context = {}
+        extra_context.update(COUNTY_CALIBRATIONS=COUNTY_CALIBRATIONS)
+        return super().changelist_view(request, extra_context)
 
     def render_change_form(self, request, context, *args, **kwargs):
         context.update({'export_form': DateRangeForm()})

--- a/camp/apps/monitors/purpleair/models.py
+++ b/camp/apps/monitors/purpleair/models.py
@@ -11,6 +11,7 @@ from resticus.encoders import JSONEncoder
 
 from camp.apps.monitors.models import Monitor, Entry
 from camp.apps.monitors.purpleair import api
+from camp.apps.monitors.purpleair.utils import COUNTY_CALIBRATIONS
 
 
 class PurpleAir(Monitor):
@@ -25,6 +26,9 @@ class PurpleAir(Monitor):
     @cached_property
     def thingspeak_key(self):
         return self.data[0]['THINGSPEAK_PRIMARY_ID_READ_KEY']
+
+    def get_pm25_calibration_formula(self):
+        return COUNTY_CALIBRATIONS.get(self.county)
 
     def get_devices(self, retries=3):
         devices = api.get_devices(self.purple_id, self.thingspeak_key)

--- a/camp/apps/monitors/purpleair/utils.py
+++ b/camp/apps/monitors/purpleair/utils.py
@@ -1,0 +1,11 @@
+
+COUNTY_CALIBRATIONS = {
+    'Fresno': '((particles_10um-particles_25um)*0.05973)+((particles_03um-particles_10um)*0.001775)',
+    'Kern': '((particles_10um-particles_25um)*0.1281462)+((particles_03um-particles_10um)*(-0.001683))+11',
+    'Kings': '((particles_10um-particles_25um)*0.12059)+((particles_03um-particles_10um)*(-0.0026352))+16',
+    'Madera': '((particles_10um-particles_25um)*0.05973)+((particles_03um-particles_10um)*0.001775)',
+    'Merced': '((particles_10um-particles_25um)*0.043751)+((particles_03um-particles_10um)*0.002805)-1.4',
+    'San Joaquin': '((particles_10um-particles_25um)*0.043751)+((particles_03um-particles_10um)*0.002805)-1.4',
+    'Stanislaus': '((particles_10um-particles_25um)*0.043751)+((particles_03um-particles_10um)*0.002805)-1.4',
+    'Tulare': '((particles_10um-particles_25um)*0.12059)+((particles_03um-particles_10um)*(-0.0026352))+16'
+}

--- a/camp/templates/admin/purpleair/purpleair/change_list.html
+++ b/camp/templates/admin/purpleair/purpleair/change_list.html
@@ -1,0 +1,28 @@
+{% extends "admin/change_list.html" %}
+
+{% block search %}
+<div class="results">
+    <table>
+        <thead>
+            <tr>
+                <th colspan="2">
+                    <div class="text">
+                        <a href="#"
+                            onclick="javascript: django.jQuery(this).parents('thead').siblings('tbody').toggle(); return false;"
+                        >View Calibration Formulas</a>
+                    </div>
+                </th>
+            </tr>
+        </thead>
+        <tbody style="display: none">
+            {% for county, formula in COUNTY_CALIBRATIONS.items %}
+            <tr>
+                <th>{{ county }}</th>
+                <td><code>{{ formula }}</code></td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{{ block.super }}
+{% endblock %}


### PR DESCRIPTION
This PR hides the `pm25_calibration_formula` field for Purple Air monitors in the Django admin, replacing it with hardcoded values on a county basis.

Why?

Because Purple Air monitors will always be calibrated by county, so it doesn't make sense to store this in the database on each individual monitor. Additionally, it allows us to more easily track changes to the formulas by county over time.

I'm leaving the `pm25_calibration_formula` in the base `Monitor` model for now, as we may want to make use of it in the future.