### PR TITLE
Remove django-yarn and manually copy vue into static/js/lib.

### DIFF
--- a/camp/settings/base.py
+++ b/camp/settings/base.py
@@ -196,21 +196,11 @@ STATICFILES_DIRS = [
 STATICFILES_FINDERS = [
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-    'yarn.finders.YarnFinder',
 ]
 
 MEDIA_ROOT = BASE_DIR.child('public', 'media')
 
 MEDIA_URL = os.environ.get('MEDIA_URL', '/media/')
-
-
-# django-yarn
-
-YARN_STATIC_FILES_PREFIX = 'js/lib'
-
-YARN_FILE_PATTERNS = {
-    'vue': ['dist/vue.min.js']
-}
 
 
 # django-cors-headers

--- a/camp/templates/pages/index.html
+++ b/camp/templates/pages/index.html
@@ -13,6 +13,6 @@
 <script type="text/javascript">
     window.GOOGLE_MAPS_API_KEY = '{{ settings.GOOGLE_MAPS_API_KEY }}';
 </script>
-<script type="text/javascript" src="{% static 'js/lib/vue/dist/vue.min.js' %}"></script>
+<script type="text/javascript" src="{% static 'js/lib/vue.min.js' %}"></script>
 <script type="text/javascript" src="{% static 'js/map.umd.min.js' %}"></script>
 {% endblock %}

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,7 +17,6 @@ django-model-utils==4.0.0
 django-smalluuid==1.2.0
 django-storages==1.9.1
 django-vanilla-views==1.1.0
-django-yarn==0.0.2
 
 argon2-cffi==20.1.0
 asgiref==3.2.10
@@ -54,4 +53,3 @@ Unipath==1.1
 whitenoise==5.2.0
 
 git+https://github.com/dmpayton/django-resticus@8cabf31d48
-git+https://github.com/epineda/django-yarn#master

--- a/tasks.py
+++ b/tasks.py
@@ -20,32 +20,32 @@ class GlobWatcher(Watcher):
         return False
 
 
-def dir(*paths):
+def path(*paths):
     if not paths[0].startswith(os.sep):
         paths = (os.getcwd(),) + paths
     return os.path.abspath(os.path.join(*paths))
 
 
-def mkdir(path):
-    path = dir(path)
-    if not os.path.exists(path):
-        os.makedirs(path)
-    return path
+def mkdir(dirname):
+    dirname = path(dirname)
+    if not os.path.exists(dirname):
+        os.makedirs(dirname)
+    return dirname
 
 
 def assets(*paths):
-    return dir('assets', *paths)
+    return path('assets', *paths)
 
 
 @invoke.task()
 def styles(ctx):
     compiled_css = sass.compile(
         filename=assets('sass/style.sass'),
-        include_paths=(assets('sass'), dir('node_modules')),
+        include_paths=(assets('sass'), path('node_modules')),
         output_style='compressed',
     )
     mkdir('dist/css')
-    with open(dir('dist/css/style.css'), 'w') as f:
+    with open(path('dist/css/style.css'), 'w') as f:
         f.write(compiled_css)
 
 
@@ -55,13 +55,23 @@ def collectstatic(ctx):
 
 
 def vue(ctx, name):
+    mkdir('./dist/js/lib')
+
+    # Copy vue itself
+    ctx.run(f'''
+        cp \
+        {path('node_modules/vue/dist/vue.min.js')} \
+        {path('./dist/js/lib/vue.min.js')}
+    ''')
+
+    # Run the build for the map
     command = f'''yarn build \
         --mode production \
         --no-clean \
         --formats umd-min \
         --target lib \
         --name {name} \
-        --dest {dir('./dist/js')} \
+        --dest {path('./dist/js')} \
         {assets(f'./{name}/main.js')}
     '''
     ctx.run(command, pty=True, warn=False)
@@ -77,9 +87,9 @@ def build(ctx):
 @invoke.task()
 def watch(ctx):
     server = livereload.Server(watcher=GlobWatcher())
-    server.watch(dir('./assets/img/'), lambda: collectstatic(ctx))
-    server.watch(assets('js'), lambda: collectstatic(ctx))
-    server.watch(assets('sass'), lambda: [styles(ctx), collectstatic(ctx)])
+    server.watch(path('./assets/img/'), lambda: collectstatic(ctx))
+    server.watch(assets('js/**'), lambda: collectstatic(ctx))
+    server.watch(assets('sass/**'), lambda: [styles(ctx), collectstatic(ctx)])
     server.watch(assets('map/**'), lambda: [vue(ctx, 'map'), collectstatic(ctx)])
-    server.watch(dir('./dist/lib/'), lambda: collectstatic(ctx))
+    server.watch(path('./dist/lib/'), lambda: collectstatic(ctx))
     server.serve()


### PR DESCRIPTION
This PR started with a version mismatch between two different versions of django-yarn that were listed in our requirements. Since we're not actually using that package, it's been removed. As a result, we had to update the tasks to manually copy vue into the dist directory.