### PR TITLE
Fix Monitor Detail

### DIFF
--- a/assets/map/components/MonitorDetail.vue
+++ b/assets/map/components/MonitorDetail.vue
@@ -133,6 +133,11 @@ export default {
     }
   },
 
+  beforeDestroy() {
+    monitorsService.clearActiveMonitor();
+    this.$router.replace("/");
+  },
+
   methods: {
     setActiveMonitor() {
       this.ctx.setActiveMonitor(this.params.id, {
@@ -141,8 +146,7 @@ export default {
       });
     },
     on_close() {
-      monitorsService.clearActiveMonitor();
-      this.$router.replace("/");
+      this.$destroy();
     },
 
     // [ Do we need | How can we use ] this?

--- a/assets/map/components/MonitorDetail.vue
+++ b/assets/map/components/MonitorDetail.vue
@@ -1,7 +1,7 @@
 <template>
 <div v-if="monitor" class="monitor-detail">
   <div class="container is-fluid">
-    <span class="monitor-close" v-on:click="on_close">
+    <span class="monitor-close" v-on:click="close">
       <span class="far fa-window-close"></span>
     </span>
     <div class="monitor-header">
@@ -145,7 +145,8 @@ export default {
         endDate: this.query.timestamp__lte
       });
     },
-    on_close() {
+
+    close() {
       this.$destroy();
     },
 


### PR DESCRIPTION
Currently if the active monitor is cleared by a user clicking the back button, the map does not return to full height. This change moves the `on_close` event handler logic to the `beforeDestroy` Vue life cycle hook. The `on_close` method was renamed to `close` to reflect that it is no longer an event handler, and now simply calls the component's `$destroy` method;