### PR TITLE
Feat: Server Soft Reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ Fully shut down the box:
 host:~/dev/sjvair.com$ vagrant halt
 ```
 
+### Help! I only see sensors on the map the first time I run `vagrant up`
+This happens because of a gap in time and data. The server will try to backfill sensor entries to the last point in time in which it was running. If you have the patience, you can wait for the server to process all of that missing data, and then everything should work as expected. For the rest of us who can't wait, we can start fresh by flushing the task queue and deleting the old sensor entries like so:
+
+```
+host:~dev/sjvair.com$ python manage.py clear_huey_and_entries
+```
+
 ### How do I access Postgres from outside my Vagrant box?
 
 If you're wanting to access the database in your Vagrant box, e.g., with

--- a/camp/api/management/commands/clear_huey_and_entries.py
+++ b/camp/api/management/commands/clear_huey_and_entries.py
@@ -1,0 +1,10 @@
+from django.core.management.base import BaseCommand
+from huey.contrib.djhuey import HUEY
+
+from camp.apps.monitors.models import Entry
+
+class Command(BaseCommand):
+    def handle(self, *args, **kwargs):
+        HUEY.pending_count()
+        HUEY.flush()
+        Entry.objects.all().delete()


### PR DESCRIPTION
Currently we have to manually clear the Huey task queue and delete monitor entries when starting up the development server after an extended period of time. This feature adds a new task for the api called 'clear_huey_and_entries' which will take care of this for us without having to drop into shell_plus.