### PR TITLE
Graph Loading Notice

### DIFF
--- a/assets/map/components/MonitorGraph/MonitorGraph.vue
+++ b/assets/map/components/MonitorGraph/MonitorGraph.vue
@@ -41,9 +41,10 @@
     </div>
   </div>
 
-   <div class="chart">
+  <div :class="{ 'is-hidden': loading }" class="chart">
     <monitor-chart :chartData="monitor.chartData" :dataFields="monitor.dataFields"></monitor-chart>
   </div>
+  <h1 v-if="loading" class="loading-notice">Fetching Data...</h1>
 </div> 
 </template>
 

--- a/assets/sass/sjvair/pages/map.sass
+++ b/assets/sass/sjvair/pages/map.sass
@@ -36,6 +36,12 @@ body.map
             font-weight: bold
 
     .monitor-graph
+        .loading-notice
+          font-size: 1.25em;
+          font-weight: 800;
+          text-align: center;
+          margin-top: 5em;
+
         .chart-container
           
           .tick

--- a/assets/sass/sjvair/pages/map.sass
+++ b/assets/sass/sjvair/pages/map.sass
@@ -17,7 +17,7 @@ body.map
                 padding-left: $gap
 
     .monitor-detail
-        padding-bottom: 1em;
+        padding-bottom: 1em
         background-color: #fff
         width: 100%
 
@@ -37,10 +37,10 @@ body.map
 
     .monitor-graph
         .loading-notice
-          font-size: 1.25em;
-          font-weight: 800;
-          text-align: center;
-          margin-top: 5em;
+          font-size: 1.25em
+          font-weight: 800
+          text-align: center
+          margin-top: 5em
 
         .chart-container
           
@@ -53,7 +53,7 @@ body.map
           .yaxis, .xaxis
 
             .domain
-              opacity: 0;
+              opacity: 0
 
           .chart-line
             stroke-width: 1
@@ -90,9 +90,9 @@ body.map
               padding: .5em
 
             .chart-tooltip-value
-              display: flex;
-              flex-direction: row;
-              align-items: center;
+              display: flex
+              flex-direction: row
+              align-items: center
               margin: .5em
 
             &.active
@@ -107,7 +107,7 @@ body.map
               stroke-dasharray: 3
 
     table.latest-stats
-        margin-top: 5em;
+        margin-top: 5em
 
         thead th
             vertical-align: center


### PR DESCRIPTION
Currently when there is no data for the monitor chart, the area is blank. This PR adds a notice to inform the user that data is loading.