### PR TITLE
Fix: Monitor Chart Tooltip

### DIFF
--- a/assets/map/utils/date.js
+++ b/assets/map/utils/date.js
@@ -14,7 +14,7 @@ Object.assign(dayjs, {
     return dayjs.utc(date).format("YYYY-MM-DD HH:mm:ss");
   },
   $prettyPrint(date) {
-    return dayjs.utc(date).format("h:mma dddd MMM DD, YYYY")
+    return dayjs.utc(date).tz('America/Los_Angeles').format("h:mma dddd MMM DD, YYYY")
   }
 });
 


### PR DESCRIPTION
The restyled tooltip currently displays the date and time in UTC. This should actually be displayed in our local timezone.

The `prettyPrint` method on our DateUtil has been updated to convert the timestamp into PST.