### PR TITLE
Fix: Monitor Graph Tooltip

### DIFF
--- a/assets/map/utils/date.js
+++ b/assets/map/utils/date.js
@@ -14,7 +14,7 @@ Object.assign(dayjs, {
     return dayjs.utc(date).format("YYYY-MM-DD HH:mm:ss");
   },
   $prettyPrint(date) {
-    return dayjs.utc(date).tz('America/Los_Angeles').format("h:mma dddd MMM DD, YYYY")
+    return dayjs(date).format("h:mma dddd MMM DD, YYYY")
   }
 });
 


### PR DESCRIPTION
Currently the monitor graph tooltip converts a date to UTC before converting it to local time. This doesn't provide the accuracy expected when taking in dates of different formats.

This change removes the conversion on the date and simply formats it instead.