### PR TITLE
Feat: Obvious Missing Data

### DIFF
--- a/assets/map/components/MonitorDetail/MonitorChart.vue
+++ b/assets/map/components/MonitorDetail/MonitorChart.vue
@@ -208,10 +208,10 @@ export default {
         const segmentsID = `chart-segments-${ i }`;
 
         const segments = computeSegments(data, lineDefined)
-        const gaps = [data.filter(lineDefined)];
+        const gaps = data.filter(lineDefined);
 
         const gapsLine = this.chart.selectAll(`.${ gapsId }`)
-          .data(gaps);
+          .data([gaps]);
 
         const segmentsLine = this.chart.selectAll(`.${ segmentsID }`)
           .data(segments);
@@ -222,7 +222,7 @@ export default {
         gapsLine.enter()
           .append("path")
           .attr("class", segmentsID)
-          .attr("d", this.pathDefinition(gaps.pop()))
+          .attr("d", this.pathDefinition(gaps))
           .attr("fill", "none");
 
         segmentsLine.enter()

--- a/camp/api/v1/monitors/serializers.py
+++ b/camp/api/v1/monitors/serializers.py
@@ -30,6 +30,7 @@ class MonitorSerializer(serializers.Serializer):
         'is_active',
         'is_sjvair',
         'position',
+        'last_active_limit',
         'location',
         'latest',
         'county'

--- a/camp/apps/monitors/models.py
+++ b/camp/apps/monitors/models.py
@@ -89,6 +89,10 @@ class Monitor(models.Model):
         cutoff = timedelta(seconds=self.LAST_ACTIVE_LIMIT)
         return (now - parse_datetime(self.latest['timestamp'])) < cutoff
 
+    @property
+    def last_active_limit(self):
+        return self.LAST_ACTIVE_LIMIT
+
     def get_pm25_calibration_formula(self):
         # Check for a formula set on this specific monitor.
         if self.pm25_calibration_formula:


### PR DESCRIPTION
The `MonitorChart` component currently renders one line segment for each data set. This causes data gaps to be rendered as a straight line, which can be confusing as it sugests there _is_ actually data there.

This PR adds two helper functions to calculate line segments, and separate `path` elements to represent segments and gaps. Missing data is determined by a maximum gap in minutes between two given points.

All missing data should now be represented by line break in the chart. The current maximum gap is based off of the `LAST_ACTIVE_LIMIT` property for a given monitor model.

Other Notes:
Test Monitor: `WPCA - Delano`
Date Range: `2021-08-03` through `2021-08-06`
