### PR TITLE
Add caching to the monitor-list endpoint, with a periodic task to refresh it every minute.

### DIFF
--- a/camp/apps/monitors/tasks.py
+++ b/camp/apps/monitors/tasks.py
@@ -1,5 +1,11 @@
-from huey.contrib.djhuey import db_task
+from django.test import RequestFactory
+from django.urls import reverse
 
+from huey import crontab
+from huey.contrib.djhuey import db_task, db_periodic_task
+
+from camp.api.v1.monitors.endpoints import MonitorList
+from camp.utils.test import get_response_data
 from .models import Entry, Monitor
 
 
@@ -9,3 +15,24 @@ def process_entry(entry_id):
     monitor = Monitor.objects.get(pk=entry.monitor_id)
     monitor.process_entry(entry)
     entry.save()
+
+
+@db_periodic_task(crontab(minute='*'), priority=100)
+def refresh_monitor_list_cache():
+    # We'll use Django's testing framework to directly call the
+    # monitor-list endpoint with cache-busting. This will force
+    # a refresh of the cache, and prevent the database from being
+    # hit too often.
+
+    monitor_list = MonitorList.as_view()
+    factory = RequestFactory()
+
+    url = reverse('api:v1:monitors:monitor-list')
+    url = f'{url}?_cc=1'
+
+    request = factory.get(url)
+    response = monitor_list(request)
+
+    content = get_response_data(response)
+    assert response.status_code == 200
+


### PR DESCRIPTION
This PR caches the response from the monitor-list endpoint (which gets hit the most) for 90 seconds. Subsequent hits to the endpoint will returned the cached version, preventing the database from being hit.

If the cache is empty, the request is run as normal, cached, and returned.

A periodic task runs every 60 seconds that regenerates the cache – more often than the cache timeout on the view. With this in place, the endpoint should almost always return a copy of the data from cache.