### PR TITLE
Feat: New Web Widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@sjvair/monitor-map": "^1.36.0",
+    "@sjvair/web-widget": "^1.0.4",
     "bulma": "^0.9.4"
   }
 }

--- a/tasks.py
+++ b/tasks.py
@@ -61,13 +61,22 @@ def collectstatic(ctx):
 @invoke.task()
 def import_monitor_map(ctx):
     # Copy over monitor map
-    ctx.run(f'rm -rf {path("./dist/{monitor-map,widget}")}')
+    ctx.run(f'rm -rf {path("./dist/monitor-map")}')
     ctx.run(f'''
         cp -r \
-        {path('node_modules/@sjvair/monitor-map/dist/{monitor-map,widget}')} \
+        {path('node_modules/@sjvair/monitor-map/dist/monitor-map')} \
         {path('./dist')}
     ''')
 
+@invoke.task()
+def import_monitor_widget(ctx):
+    # Copy over monitor map
+    ctx.run(f'rm -rf {path("./dist/widget")}')
+    ctx.run(f'''
+        cp -r \
+        {path('node_modules/@sjvair/web-widget/dist')} \
+        {path('./dist/widget')}
+    ''')
 
 @invoke.task()
 def build(ctx):
@@ -76,6 +85,7 @@ def build(ctx):
     mkdir(path('dist'))
 
     import_monitor_map(ctx)
+    import_monitor_widget(ctx)
     styles(ctx)
     collectstatic(ctx)
     optimize_images(ctx)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,10 +4,15 @@
 
 "@sjvair/monitor-map@^1.36.0":
   version "1.36.0"
-  resolved "https://registry.yarnpkg.com/@sjvair/monitor-map/-/monitor-map-1.36.0.tgz#3b8d201935fbca550d947654c845e91a0e66c203"
+  resolved "https://registry.npmjs.org/@sjvair/monitor-map/-/monitor-map-1.36.0.tgz"
   integrity sha512-DsErwHye4ibNcPerF7IKvtvctMCzO/BNE7Iua625eD47JH6Cthp8iHXKCiOEjaq7gJTL4rmKT/bxsvEb24ojyQ==
+
+"@sjvair/web-widget@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@sjvair/web-widget/-/web-widget-1.0.4.tgz#722f2a646f4abeaa898bfc9646838c9a71a42733"
+  integrity sha512-oECrsG59bdM/VUZCRuPW0kC70b3hdGvysqdl/K0qKadxnrGtVaCsDQlIcRsI5ml6nL0oAbkB3dvFsL4lh54X4w==
 
 bulma@^0.9.4:
   version "0.9.4"
-  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.9.4.tgz#0ca8aeb1847a34264768dba26a064c8be72674a1"
+  resolved "https://registry.npmjs.org/bulma/-/bulma-0.9.4.tgz"
   integrity sha512-86FlT5+1GrsgKbPLRRY7cGDg8fsJiP/jzTqXXVqiUZZ2aZT8uemEOHlU1CDU+TxklPEZ11HZNNWclRBBecP4CQ==


### PR DESCRIPTION
This replaces the old style widget with a more compact and simplified version. The widget included in the @sjvair/monitor-map package is no longer used, and will be removed in future updates to the package. The new web widget, provided by [@sjvair/web-widget](https://www.npmjs.com/package/@sjvair/web-widget), may be accessed from `https://www.sjvair.com/static/widget/index.html#/[ MONITOR_ID ]`