### PR TITLE
Add slightly better detection of possible indoor monitors.

### DIFF
--- a/camp/apps/monitors/purpleair/models.py
+++ b/camp/apps/monitors/purpleair/models.py
@@ -46,10 +46,24 @@ class PurpleAir(Monitor):
             float(data['longitude']),
             float(data['latitude'])
         )
-        self.location = self.LOCATION.inside if data['location_type'] == 1 else self.LOCATION.outside
+        self.location = self.get_probable_location(data)
 
         if not self.default_sensor:
             self.default_sensor = 'a'
+
+    def get_probable_location(self, data):
+        # Check for an explicit flag
+        if data['location_type'] == 1:
+            return self.LOCATION.inside
+
+        # If the name says it's inside, it probably is
+        name = data['name'].lower()
+        inside_list = ('inside', 'indoor', 'in door', 'in-door')
+        if any(item in name for item in inside_list):
+            return self.LOCATION.inside
+
+        # If we're here, it's probably outside.
+        return self.LOCATION.outside
 
     def create_entry(self, payload, sensor=None):
         try:

--- a/camp/apps/monitors/purpleair/tests.py
+++ b/camp/apps/monitors/purpleair/tests.py
@@ -20,8 +20,14 @@ class PurpleAirTests(TestCase):
         assert a.position == self.monitor.position
         assert a.fahrenheit == payload['temperature']
 
-    # def test_thing(self):
-    #     qs = PurpleAir.objects.annotate(
-    #         last_updated=Max('entries__timestamp')
-    #     )
-    #     print(qs.get().last_updated)
+    def test_probable_location_marked_inside(self):
+        payload = {'name': 'test', 'location_type': 1}
+        assert PurpleAir().get_probable_location(payload) == PurpleAir.LOCATION.inside
+
+    def test_probable_location_marked_outside_name_implies_inside(self):
+        payload = {'name': 'test indoor', 'location_type': 0}
+        assert PurpleAir().get_probable_location(payload) == PurpleAir.LOCATION.inside
+
+    def test_probable_location_marked_outside(self):
+        payload = {'name': 'test outdoor', 'location_type': 0}
+        assert PurpleAir().get_probable_location(payload) == PurpleAir.LOCATION.outside


### PR DESCRIPTION
This PR changes PurpleAir data updates to account for monitors that are listed as being outside but the meta data (name) implies that the monitor is actually inside.

This hasn't been a problem for us (yet), but this exact issue was reported by other groups during the EPA's Air Sensor QA Workshop 2023, and I'd like to try and prevent it from happening to us.