### PR TITLE
Export monitor list CSV from Django admin

### DIFF
--- a/camp/apps/monitors/purpleair/admin.py
+++ b/camp/apps/monitors/purpleair/admin.py
@@ -9,6 +9,9 @@ from camp.apps.monitors.purpleair.models import PurpleAir
 
 @admin.register(PurpleAir)
 class PurpleAirAdmin(MonitorAdmin):
+    csv_export_fields = MonitorAdmin.csv_export_fields[:]
+    csv_export_fields.insert(2, 'purple_id')
+
     list_display = MonitorAdmin.list_display[:]
     list_display.insert(1, 'purple_id')
     list_display.insert(5, 'get_active_status')


### PR DESCRIPTION
- Custom `MonitorIsActiveFilter` filter for showing in/active monitors in the admin
- Custom 'export_monitor_list_csv' action to export as csv

This allows admins to, e.g., export a CSV of all monitors where `is_sjavir == true` and `is_active == false`.

<img width="1061" alt="Screenshot 2023-09-13 at 3 08 12 AM" src="https://github.com/SJVAir/sjvair.com/assets/149918/8a97e5ea-dd75-4f55-a3ed-aa38ace8bc24">
