### PR TITLE
Multiple task worker queues.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,5 @@
 release: invoke release
 web: gunicorn --config gunicorn-config.py camp.wsgi:application
-huey_scheduler: python manage.py run_huey
-huey_worker: python manage.py run_huey --no-periodic
+huey_primary_scheduler: python manage.py djangohuey --queue primary
+huey_primary_worker: python manage.py djangohuey --queue primary --no-periodic
+huey_secondary_worker: python manage.py djangohuey --queue secondary --no-periodic

--- a/camp/apps/accounts/tasks.py
+++ b/camp/apps/accounts/tasks.py
@@ -5,10 +5,10 @@ from django.conf import settings
 import twilio.rest
 from twilio.base.exceptions import TwilioRestException
 
-from huey.contrib.djhuey import db_task as task
+from django_huey import db_task
 
 
-@task(priority=100)
+@db_task(priority=100)
 def send_sms_message(phone_number, message):
     twilio_client = twilio.rest.Client(
         settings.TWILIO_ACCOUNT_SID,

--- a/camp/apps/alerts/tasks.py
+++ b/camp/apps/alerts/tasks.py
@@ -1,8 +1,8 @@
 from django.db.models import Avg, Prefetch
 from django.utils import timezone
 
+from django_huey import db_task, db_periodic_task
 from huey import crontab
-from huey.contrib.djhuey import db_task, db_periodic_task
 
 from camp.apps.alerts.models import LEVELS, PM25_LEVELS, Alert
 from camp.apps.monitors.models import Monitor

--- a/camp/apps/archive/tasks.py
+++ b/camp/apps/archive/tasks.py
@@ -2,8 +2,8 @@ from datetime import timedelta
 
 from django.utils import timezone
 
+from django_huey import db_periodic_task, db_task
 from huey import crontab
-from huey.contrib.djhuey import db_periodic_task, db_task
 
 from camp.apps.archive.models import EntryArchive
 from camp.apps.monitors.models import Monitor

--- a/camp/apps/calibrations/tasks.py
+++ b/camp/apps/calibrations/tasks.py
@@ -1,5 +1,5 @@
+from django_huey import db_periodic_task
 from huey import crontab
-from huey.contrib.djhuey import db_periodic_task
 
 from .models import Calibrator
 

--- a/camp/apps/monitors/airnow/tasks.py
+++ b/camp/apps/monitors/airnow/tasks.py
@@ -3,8 +3,8 @@ from django.contrib.gis.geos import Point
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 
+from django_huey import db_task, db_periodic_task
 from huey import crontab
-from huey.contrib.djhuey import db_task, db_periodic_task, HUEY
 
 from camp.apps.monitors.models import Entry
 from camp.apps.monitors.airnow.models import AirNow

--- a/camp/apps/monitors/purpleair/tasks.py
+++ b/camp/apps/monitors/purpleair/tasks.py
@@ -8,9 +8,8 @@ from django.db.models import F, OuterRef, Subquery
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 
+from django_huey import db_task, db_periodic_task
 from huey import crontab
-from huey.contrib.djhuey import db_task, db_periodic_task, HUEY
-from huey.exceptions import TaskLockedException
 
 from camp.apps.monitors.models import Entry
 from camp.apps.monitors.purpleair.api import purpleair_api
@@ -19,10 +18,6 @@ from camp.apps.monitors.purpleair.models import PurpleAir
 
 @db_periodic_task(crontab(minute='*/2'), priority=50)
 def update_realtime():
-    print('[update_realtime]')
-    if HUEY.pending_count() > settings.MAX_QUEUE_SIZE:
-        return
-
     sensors = purpleair_api.list_group_members(settings.PURPLEAIR_GROUP_ID)
     for sensor in sensors:
         process_data.schedule([sensor], delay=1, priority=40)

--- a/camp/apps/monitors/tasks.py
+++ b/camp/apps/monitors/tasks.py
@@ -7,8 +7,8 @@ from django.test import RequestFactory
 from django.urls import reverse
 from django.utils import timezone
 
+from django_huey import db_task, db_periodic_task
 from huey import crontab
-from huey.contrib.djhuey import db_task, db_periodic_task
 
 from camp.api.v1.monitors.endpoints import MonitorList
 from camp.utils.test import get_response_data
@@ -72,7 +72,7 @@ def check_monitor_status():
         )
 
 
-@db_task(priority=1)
+@db_task(queue='secondary')
 def recalibrate_entry(entry_id):
     entry = Entry.objects.get(pk=entry_id)
     entry.calibrate_pm25()

--- a/camp/apps/qaqc/tasks.py
+++ b/camp/apps/qaqc/tasks.py
@@ -1,5 +1,5 @@
+from django_huey import db_periodic_task
 from huey import crontab
-from huey.contrib.djhuey import db_periodic_task
 
 from camp.apps.qaqc.sensorlinreg import SensorLinearRegression
 from camp.apps.monitors.models import Monitor

--- a/camp/settings/base.py
+++ b/camp/settings/base.py
@@ -61,6 +61,7 @@ INSTALLED_APPS = [
     'django_admin_inline_paginator',
     'django_extensions',
     'django_filters',
+    'django_huey',
     'form_utils',
     'huey.contrib.djhuey',
     'livereload',
@@ -254,18 +255,38 @@ RESTICUS = {
 }
 
 
-# huey
+# huey / django-huey
 
 MAX_QUEUE_SIZE = int(os.environ.get('MAX_QUEUE_SIZE', 500))
 
+DJANGO_HUEY = {
+    'default': 'primary',
+    'queues': {
+        'primary': {
+            'name': 'primary_tasks',
+            'connection': {'url': f'{REDIS_URL}/0'},
+            'consumer': {
+                'periodic': True,
+                'workers': int(os.environ.get('HUEY_WORKERS', 4))
+            },
+            'huey_class': 'huey.PriorityRedisHuey',
+            'immediate': bool(int(os.environ.get('HUEY_IMMEDIATE', DEBUG)))
+        },
+        'secondary': {
+            'name': 'secondary_tasks',
+            'connection': {'url': f'{REDIS_URL}/1'},
+            'consumer': {
+                'periodic': False,
+                'workers': int(os.environ.get('HUEY_WORKERS', 4))
+            },
+            'huey_class': 'huey.PriorityRedisHuey',
+            'immediate': bool(int(os.environ.get('HUEY_IMMEDIATE', DEBUG)))
+        },
+    }
+}
+
 HUEY = {
-    "connection": {"url": REDIS_URL},
-    "consumer": {
-        "periodic": True,
-        "workers": int(os.environ.get('HUEY_WORKERS', 4))
-    },
-    'huey_class': 'huey.PriorityRedisHuey',
-    "immediate": bool(int(os.environ.get('HUEY_IMMEDIATE', DEBUG)))
+    
 }
 
 # Twilio

--- a/camp/templates/admin/index.html
+++ b/camp/templates/admin/index.html
@@ -43,7 +43,12 @@
                     new Date(Date.parse(data.timestamp))
                         .toLocaleString('en-us', {timezone: 'America/Los_Angeles'}));
                 $('#id_entry-count').text(roundOOM(data.entry_count).toLocaleString());
-                $('#id_queue-size').text(data.queue_size.toLocaleString());
+
+                for (const key in data.queue_size) {
+                    console.log(`.queue-${key} .size`);
+                    console.log(data.queue_size[key].toLocaleString());
+                    $(`.queue-${key} .size`).text(data.queue_size[key].toLocaleString());
+                }
             });
         };
 
@@ -99,16 +104,18 @@
                 <th>Monitor Entries</th>
                 <td>≈<span id="id_entry-count"></span></td>
             </tr>
-            <tr>
-                <th>Task Queue</th>
+            {% for key in settings.DJANGO_HUEY.queues.keys %}
+            <tr class="queue queue-{{ key }}">
+                <th>Queue: {{ key }}</th>
                 <td>
-                    <span id="id_queue-size"></span>
-                    <form action="{% url 'flush-queue' %}" method="POST">
+                    <div class="size"></div>
+                    <form action="{% url 'flush-queue' key=key %}" method="POST">
                         {% csrf_token %}
                         <button type="submit">Flush queue</button>
                     </form>
                 </td>
             </tr>
+            {% endfor %}
         </table>
     </div>
     <div class="module" id="recent-actions-module">

--- a/camp/urls.py
+++ b/camp/urls.py
@@ -20,7 +20,7 @@ urlpatterns = [
     # Admin-y stuff
     path('admin/', include('admin_honeypot.urls', namespace='admin_honeypot')),
     path('batcave/stats.json', AdminStats.as_view(), name='admin-stats'),
-    path('batcave/flush-queue/', FlushQueue.as_view(), name='flush-queue'),
+    path('batcave/flush-queue/<str:key>/', FlushQueue.as_view(), name='flush-queue'),
     path('batcave/', admin.site.urls),
 ]
 

--- a/camp/utils/management/commands/huey_monitor.py
+++ b/camp/utils/management/commands/huey_monitor.py
@@ -4,16 +4,20 @@ import time
 from django.core.management.base import BaseCommand
 
 import asciichartpy
-from huey.contrib.djhuey import HUEY
+from django_huey import get_queue
 
 
 class Command(BaseCommand):
-    def handle(self, *args, **kwargs):
+    def add_arguments(self, parser):
+        parser.add_argument('--queue', '-q', action='store', type=str)
+
+    def handle(self, *args, **options):
+        queue = get_queue(options['queue'])
         pending_tasks = []
         try:
             while True:
                 terminal_size = os.get_terminal_size()
-                pending_tasks.append(HUEY.pending_count())
+                pending_tasks.append(queue.pending_count())
                 pending_tasks = pending_tasks[-(terminal_size.columns - 15):]
 
                 os.system('clear')
@@ -24,6 +28,7 @@ class Command(BaseCommand):
                     'format': '{:8.0f}',
                     'colors': [asciichartpy.lightmagenta],
                 }))
+                print(f'Queue: {queue.name}')
                 print(f'Pending Tasks: {pending_tasks[-1]}')
 
                 time.sleep(1)

--- a/camp/utils/management/commands/huey_monitor.py
+++ b/camp/utils/management/commands/huey_monitor.py
@@ -1,6 +1,7 @@
 import os
 import time
 
+from django.conf import settings
 from django.core.management.base import BaseCommand
 
 import asciichartpy
@@ -11,25 +12,42 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('--queue', '-q', action='store', type=str)
 
+    def get_keys(self, key=None):
+        if key is not None:
+            return [key]
+        return list(settings.DJANGO_HUEY['queues'].keys())
+
     def handle(self, *args, **options):
-        queue = get_queue(options['queue'])
-        pending_tasks = []
+        self.keys = self.get_keys(options.get('queue'))
+        self.queues = {key: get_queue(key) for key in self.keys}
+        self.tasks = {key: [] for key in self.keys}
+        colors = [asciichartpy.lightmagenta, asciichartpy.lightcyan]
+
         try:
             while True:
                 terminal_size = os.get_terminal_size()
-                pending_tasks.append(queue.pending_count())
-                pending_tasks = pending_tasks[-(terminal_size.columns - 15):]
+
+                for key in self.keys:
+                    self.tasks[key].append(self.queues[key].pending_count())
+                    self.tasks[key] = self.tasks[key][-(terminal_size.columns - 15):]
 
                 os.system('clear')
 
-                print(asciichartpy.plot(pending_tasks, {
+                print(asciichartpy.plot([self.tasks[key] for key in self.keys], {
                     'min': 0,
                     'height': max(10, terminal_size.lines - 10),
                     'format': '{:8.0f}',
-                    'colors': [asciichartpy.lightmagenta],
+                    'colors': colors,
                 }))
-                print(f'Queue: {queue.name}')
-                print(f'Pending Tasks: {pending_tasks[-1]}')
+
+                print('')
+                for i, key in enumerate(self.keys):
+                    try:
+                        color = colors[i]
+                    except IndexError:
+                        color = asciichartpy.default
+
+                    print(f'{color}{key}{asciichartpy.reset}: {self.tasks[key][-1]}')
 
                 time.sleep(1)
         except KeyboardInterrupt:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,6 +13,7 @@ django-dirtyfields==1.9.2
 django-extensions==3.2.3
 django-filter==23.2
 django-heroku==0.3.1
+django-huey==1.1.1
 django-localflavor==4.0
 django-model-utils==4.3.1
 django-phonenumber-field[phonenumberslite]==7.1.0


### PR DESCRIPTION
Pull in [django-huey](https://github.com/gaiacoop/django-huey), which is a wrapper around Huey functionality. It gives us multiple queues and allows us to do large batches of background processing without blocking our regular tasks.

This PR also updates the Django admin and huey_monitor commands to account for multiple queues.

We have two queues now, primary and secondary. The primary queue will be used the same as it always has – for our regular tasks, importing from PurpleAir, etc. The secondary queue can be used for large sets of operations, e.g., recalibrating multiple days of entries across all our monitors. The secondary queue will be turned off most of the time, but we can spin it up when we have stuff to run on it.

Old command:

```
python manage.py run_huey
```

New commands:

```
python manage.py djangohuey  # same as --queue primary
python manage.py djangohuey --queue primary
python manage.py djangohuey --queue secondary
```

The huey monitor also supports specificing the queue:

```
python manage.py huey_monitor  # Display all queues
python manage.py huey_monitor --queue primary
python manage.py huey_monitor --queue secondary
```