### PR TITLE
Calibrator list API endpoint

### DIFF
--- a/camp/api/v1/calibrations/endpoints.py
+++ b/camp/api/v1/calibrations/endpoints.py
@@ -1,0 +1,16 @@
+from resticus import generics
+
+from camp.apps.calibrations.models import Calibrator
+
+from .serializers import CalibratorSerializer
+
+
+class CalibratorList(generics.ListEndpoint):
+    model = Calibrator
+    serializer_class = CalibratorSerializer
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        queryset = queryset.filter(is_enabled=True)
+        queryset = queryset.select_related('reference')
+        return queryset

--- a/camp/api/v1/calibrations/serializers.py
+++ b/camp/api/v1/calibrations/serializers.py
@@ -1,0 +1,12 @@
+import json
+
+from resticus import serializers
+
+class CalibratorSerializer(serializers.Serializer):
+    fields = [
+        'id',
+        'reference_id',
+        'colocated_id',
+        ('name', lambda i: i.reference.name),
+        ('position', lambda i: json.loads(i.reference.position.geojson)),
+    ]

--- a/camp/api/v1/calibrations/urls.py
+++ b/camp/api/v1/calibrations/urls.py
@@ -1,0 +1,9 @@
+from django.urls import include, path
+
+from . import endpoints
+
+app_name = 'calibrations'
+
+urlpatterns = [
+    path('', endpoints.CalibratorList.as_view(), name='calibrator-list'),
+]

--- a/camp/api/v1/urls.py
+++ b/camp/api/v1/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path('time/', endpoints.CurrentTime.as_view(), name='current-time'),
     path('alerts/subscriptions/', SubscriptionList.as_view(), name='subscription-list'),
     path('monitors/', include('camp.api.v1.monitors.urls', namespace='monitors')),
+    path('calibrations/', include('camp.api.v1.calibrations.urls', namespace='calibrations')),
     path('methane/<int:methane_id>/upload/', MethaneDataUpload.as_view(), name='methane-data-upload'),
     path('methane/<int:methane_id>/data/', MethaneData.as_view(), name='methane-data'),
     path('marker.png', endpoints.MapMarker.as_view(), name='marker'),


### PR DESCRIPTION
First stab at a calibrator list API endpoint. This will drive the eventual calibration map layer.

URL: `/api/1.0/calibrations/`
Response:

```
{
  "data": [
    {
      "id": "Z5_F6iajRtCjKY4UjN9lEQ",
      "reference_id": "3HmHJdjATzmq_eCyQ2GgrA",
      "colocated_id": "Q2jt0mFjROWYehNNcEU8gA",
      "name": "Turlock - S. Minaret Street",
      "position": {
        "type": "Point",
        "coordinates": [
          -120.8358,
          37.4883
        ]
      }
    },

    ...

  ],
  "page": 1,
  "count": 14,
  "pages": 1,
  "has_next_page": false,
  "has_previous_page": false
}
```