### PR TITLE
Fix: Closest Monitor

### DIFF
--- a/camp/api/v1/monitors/endpoints.py
+++ b/camp/api/v1/monitors/endpoints.py
@@ -84,6 +84,7 @@ class ClosestMonitor(MonitorMixin, generics.ListEndpoint):
 
         queryset = super().get_queryset()
         queryset = (queryset
+            .get_active()
             .exclude(is_hidden=True)
             .exclude(latest__isnull=True)
             .exclude(location='inside')


### PR DESCRIPTION
The closest monitor endpoint now returns the closest **active** monitor, rather than just the closest monitor.