### PR TITLE
App redirect

### DIFF
--- a/camp/settings/base.py
+++ b/camp/settings/base.py
@@ -240,6 +240,17 @@ SJVAIR_INACTIVE_ALERT_EMAILS = [email.strip() for email in
 SJVAIR_CONTACT_EMAILS = [email.strip() for email in
     os.environ.get('SJVAIR_CONTACT_EMAILS', SERVER_EMAIL).split(',')]
 
+# App URLs
+
+APP_URL_ANDROID = os.environ.get('APP_URL_ANDROID',
+    'https://play.google.com/store/apps/details?id=com.sjvair.mobile')
+
+APP_URL_IPAD = os.environ.get('APP_URL_IPAD',
+    'https://apps.apple.com/us/app/sjvair/id6448961840?platform=ipad')
+
+APP_URL_IPHONE = os.environ.get('APP_URL_IPHONE',
+    'https://apps.apple.com/us/app/sjvair/id6448961840?platform=iphone')
+
 # django-cors-headers
 
 CORS_ORIGIN_ALLOW_ALL = True

--- a/camp/templates/pages/app.html
+++ b/camp/templates/pages/app.html
@@ -14,10 +14,10 @@
                 <h1 class="title">Get to know the air you're breathing.</h1>
                 <p class="lead">Download the SJVAir app and stay on top of your local air quality and weather. For iOS and Android.</p>
                 <ul class="badges is-inline">
-                    <li><a href="https://apps.apple.com/us/app/sjvair/id6448961840?platform=iphone">
+                    <li><a href="{{ settings.APP_URL_IPHONE }}">
                         <img src="{% static 'img/app/apple-app-store-badge.svg' %}" alt="Download for iPhone" />
                     </a></li>
-                    <li><a href="https://play.google.com/store/apps/details?id=com.sjvair.mobile">
+                    <li><a href="{{ settings.APP_URL_ANDROID }}">
                         <img src="{% static 'img/app/google-play-store-badge.svg' %}" alt="Download for Android" />
                     </a></li>
                 </ul>

--- a/camp/urls.py
+++ b/camp/urls.py
@@ -3,25 +3,25 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path, re_path 
 
-from camp.utils.views import PageTemplate, AdminStats, FlushQueue, RenderStatic
+from camp.utils import views
 
 admin.site.site_title = "SJVAir Admin"
 admin.site.site_header = "SJVAir Admin"
-# admin.site.site_url = None
 
 urlpatterns = [
     path('api/', include('camp.api.urls', namespace='api')),
     path('account/', include(('camp.apps.accounts.urls', 'account'), namespace='account')),
     path('contact/', include(('camp.apps.contact.urls', 'contact'), namespace='contact')),
+    path('app/', views.GetTheApp.as_view(), name='app'),
 
     # @sjvair/monitor-map specific routes
-    path('monitor/<monitor_id>/', PageTemplate.as_view(template_name='pages/index.html')),
-    path('widget/', RenderStatic.as_view(static_file='widget/index.html')),
+    path('monitor/<monitor_id>/', views.PageTemplate.as_view(template_name='pages/index.html')),
+    path('widget/', views.RenderStatic.as_view(static_file='widget/index.html')),
 
     # Admin-y stuff
     path('admin/', include('admin_honeypot.urls', namespace='admin_honeypot')),
-    path('batcave/stats.json', AdminStats.as_view(), name='admin-stats'),
-    path('batcave/flush-queue/<str:key>/', FlushQueue.as_view(), name='flush-queue'),
+    path('batcave/stats.json', views.AdminStats.as_view(), name='admin-stats'),
+    path('batcave/flush-queue/<str:key>/', views.FlushQueue.as_view(), name='flush-queue'),
     path('batcave/', admin.site.urls),
 ]
 
@@ -31,4 +31,4 @@ if settings.DEBUG:
     # urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 # Catch-all to render templates based on the path
-urlpatterns += [re_path('^', PageTemplate.as_view())]
+urlpatterns += [re_path('^', views.PageTemplate.as_view())]

--- a/camp/utils/views.py
+++ b/camp/utils/views.py
@@ -17,8 +17,11 @@ from django.utils.http import url_has_allowed_host_and_scheme
 from django.views import generic
 from django.views.decorators.clickjacking import xframe_options_exempt
 
+import vanilla
+
 from django_huey import get_queue
 from resticus.http import JSONResponse
+from ua_parser import user_agent_parser
 
 from camp.apps.monitors.models import Entry
 
@@ -103,6 +106,23 @@ class PageTemplate(generic.TemplateView):
             raise Http404
 
         return self.render_to_response({})
+
+
+class GetTheApp(vanilla.TemplateView):
+    template_name = 'pages/app.html'
+
+    def get(self, request):
+        user_agent = user_agent_parser.Parse(request.META.get('HTTP_USER_AGENT', ''))
+        if user_agent['os']['family'] == 'Android':
+            return redirect(settings.APP_URL_ANDROID)
+
+        if user_agent['device']['family'] == 'iPhone':
+            return redirect(settings.APP_URL_IPHONE)
+
+        if user_agent['device']['family'] == 'iPad':
+            return redirect(settings.APP_URL_IPAD)
+
+        return super().get(request)
 
 
 @method_decorator(xframe_options_exempt, name='dispatch')

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -63,6 +63,7 @@ scikit-learn==1.3.0
 scout-apm==2.26.1
 sentry-sdk==1.29.2
 twilio==8.5.0
+ua-parser==0.18.0
 Unipath==1.1
 whitenoise==6.5.0
 


### PR DESCRIPTION
Update the `/app/` URL to redirect to the appropriate app store if the user is on a mobile device. If the user is not on a mobile device, the `pages/app.html` template gets rendered as it always has. This makes it so we can use [sjvair.com/app](sjvair.com/app) as the URL for all marketing materials, and it will do the Right Thing™ based on what device the user is on.

This adds a few new settings that we can easily be tweaked by the environment...

- `APP_URL_ANDROID`
- `APP_URL_IPAD`
- `APP_URL_IPHONE`

...But we'll roll with the hard-coded defaults until there's a need to change 'em.