### PR TITLE
feat(queues): primary-queue huey stats dashboard in admin

### DIFF
--- a/camp/apps/queues/apps.py
+++ b/camp/apps/queues/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class QueuesConfig(AppConfig):
+    name = 'camp.apps.queues'
+
+    def ready(self):
+        from .stats import configure_queue_stats
+        configure_queue_stats('primary')

--- a/camp/apps/queues/stats.py
+++ b/camp/apps/queues/stats.py
@@ -1,27 +1,38 @@
+import logging
+
+logger = logging.getLogger('huey')
+
+
 def configure_queue_stats(queue_name, queue=None, db=None):
     """Attach huey's stats recorder to a django-huey queue and point the
     built-in dashboard admin at that same instance.
 
     Idempotent per huey instance (``enable_stats`` no-ops if already attached).
     Returns the wired queue, or ``None`` when the queue runs in immediate mode
-    (tests / local DEBUG), where there is no consumer to monitor.
+    (tests / local DEBUG), where there is no consumer to monitor. Any failure
+    (e.g. huey internals moving on a future upgrade) is logged and swallowed so
+    a broken dashboard never stops a process from starting.
     """
-    from django_huey import get_queue
-    from huey.contrib.stats import enable_stats
-    from huey.contrib.djhuey.stats import admin as stats_admin
-    from huey.contrib.djhuey.stats.apps import stats_database
+    try:
+        from django_huey import get_queue
+        from huey.contrib.stats import enable_stats
+        from huey.contrib.djhuey.stats import admin as stats_admin
+        from huey.contrib.djhuey.stats.apps import stats_database
 
-    if queue is None:
-        queue = get_queue(queue_name)
+        if queue is None:
+            queue = get_queue(queue_name)
 
-    if queue.immediate:
+        if queue.immediate:
+            return None
+
+        if db is None:
+            db, options = stats_database()
+        else:
+            options = {}
+
+        enable_stats(queue, db, **options)
+        stats_admin.get_huey = lambda: queue
+        return queue
+    except Exception:
+        logger.exception('Failed to wire huey stats dashboard for queue %r', queue_name)
         return None
-
-    if db is None:
-        db, options = stats_database()
-    else:
-        options = {}
-
-    enable_stats(queue, db, **options)
-    stats_admin.get_huey = lambda: queue
-    return queue

--- a/camp/apps/queues/stats.py
+++ b/camp/apps/queues/stats.py
@@ -1,0 +1,27 @@
+def configure_queue_stats(queue_name, queue=None, db=None):
+    """Attach huey's stats recorder to a django-huey queue and point the
+    built-in dashboard admin at that same instance.
+
+    Idempotent per huey instance (``enable_stats`` no-ops if already attached).
+    Returns the wired queue, or ``None`` when the queue runs in immediate mode
+    (tests / local DEBUG), where there is no consumer to monitor.
+    """
+    from django_huey import get_queue
+    from huey.contrib.stats import enable_stats
+    from huey.contrib.djhuey.stats import admin as stats_admin
+    from huey.contrib.djhuey.stats.apps import stats_database
+
+    if queue is None:
+        queue = get_queue(queue_name)
+
+    if queue.immediate:
+        return None
+
+    if db is None:
+        db, options = stats_database()
+    else:
+        options = {}
+
+    enable_stats(queue, db, **options)
+    stats_admin.get_huey = lambda: queue
+    return queue

--- a/camp/apps/queues/tests.py
+++ b/camp/apps/queues/tests.py
@@ -1,0 +1,35 @@
+import peewee
+from django.test import TestCase
+from huey import MemoryHuey
+from huey.contrib.djhuey.stats import admin as stats_admin
+
+from camp.apps.queues.stats import configure_queue_stats
+
+
+class ConfigureQueueStatsTests(TestCase):
+    def setUp(self):
+        # Restore the dashboard's queue resolver after each test so the
+        # monkeypatch never leaks between tests.
+        original = stats_admin.get_huey
+        self.original_get_huey = original
+        self.addCleanup(setattr, stats_admin, 'get_huey', original)
+
+    def test_wires_recorder_and_dashboard_for_live_queue(self):
+        queue = MemoryHuey('test-live', immediate=False)
+        db = peewee.SqliteDatabase(':memory:')
+
+        result = configure_queue_stats('ignored', queue=queue, db=db)
+
+        assert result is queue
+        assert getattr(queue, '_stats', None) is not None
+        assert stats_admin.get_huey() is queue
+
+    def test_noop_when_queue_is_immediate(self):
+        queue = MemoryHuey('test-immediate', immediate=True)
+        db = peewee.SqliteDatabase(':memory:')
+
+        result = configure_queue_stats('ignored', queue=queue, db=db)
+
+        assert result is None
+        assert getattr(queue, '_stats', None) is None
+        assert stats_admin.get_huey is self.original_get_huey

--- a/camp/apps/queues/tests.py
+++ b/camp/apps/queues/tests.py
@@ -33,3 +33,15 @@ class ConfigureQueueStatsTests(TestCase):
         assert result is None
         assert getattr(queue, '_stats', None) is None
         assert stats_admin.get_huey is self.original_get_huey
+
+    def test_swallows_errors_and_leaves_dashboard_untouched(self):
+        from unittest import mock
+
+        queue = MemoryHuey('test-error', immediate=False)
+        db = peewee.SqliteDatabase(':memory:')
+
+        with mock.patch('huey.contrib.stats.enable_stats', side_effect=RuntimeError('boom')):
+            result = configure_queue_stats('ignored', queue=queue, db=db)
+
+        assert result is None
+        assert stats_admin.get_huey is self.original_get_huey

--- a/camp/settings/base.py
+++ b/camp/settings/base.py
@@ -365,6 +365,8 @@ DJANGO_HUEY = {
 
 HUEY_STATS = {
     'capture_args': False,
+    'retention_hours': 24,
+    'max_events': 250_000,
 }
 
 MAX_QUEUE_SIZE = int(env('MAX_QUEUE_SIZE', 500))

--- a/camp/settings/base.py
+++ b/camp/settings/base.py
@@ -86,6 +86,7 @@ INSTALLED_APPS = [
     'django_recaptcha',
     'form_utils',
     'huey.contrib.djhuey',
+    'huey.contrib.djhuey.stats',
     'livereload',
     'localflavor',
     'pgactivity',
@@ -359,6 +360,10 @@ DJANGO_HUEY = {
             'immediate': bool(int(env('HUEY_IMMEDIATE', DEBUG)))
         },
     }
+}
+
+HUEY_STATS = {
+    'capture_args': False,
 }
 
 MAX_QUEUE_SIZE = int(env('MAX_QUEUE_SIZE', 500))

--- a/camp/settings/base.py
+++ b/camp/settings/base.py
@@ -119,6 +119,7 @@ INSTALLED_APPS = [
     'camp.apps.regions',
     'camp.apps.summaries',
     'camp.apps.qaqc',
+    'camp.apps.queues',
     'camp.utils',
 ]
 

--- a/camp/settings/test.py
+++ b/camp/settings/test.py
@@ -51,3 +51,10 @@ DJANGO_HUEY = {
         },
     }
 }
+
+# Huey stats — keep the test Postgres untouched; the vendor stats app's
+# startup recorder writes its (empty) tables to a throwaway sqlite db instead.
+HUEY_STATS = {
+    'capture_args': False,
+    'database': 'sqlite:///:memory:',
+}

--- a/camp/templates/admin/index.html
+++ b/camp/templates/admin/index.html
@@ -175,7 +175,13 @@
                         {% for key in settings.DJANGO_HUEY.queues.keys %}
                         <li class="queue queue-{{ key }}">
                             <div style="display:flex;justify-content:space-between;align-items:center">
-                                <span>{{ key|title }}</span>
+                                {% if forloop.first %}
+                                    <a href="{% url 'admin:hueystats_hueydashboard_changelist' %}">
+                                        <span>{{ key|title }}</span>
+                                    </a>
+                                {% else %}
+                                    <span>{{ key|title }}</span>
+                                {% endif %}
                                 <form action="{% url 'flush-queue' key=key %}" method="POST" style="display:inline">
                                     {% csrf_token %}
                                     <span style="font-weight:bold;" class="size"></span>

--- a/docs/superpowers/plans/2026-07-23-huey-primary-dashboard.md
+++ b/docs/superpowers/plans/2026-07-23-huey-primary-dashboard.md
@@ -1,0 +1,328 @@
+# Huey primary-queue admin dashboard — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a single Django-admin dashboard page showing live task stats for the `primary` `django_huey` queue, using huey's built-in `huey.contrib.djhuey.stats`, without disturbing the multi-queue setup.
+
+**Architecture:** Upgrade huey to a version that ships the stats dashboard, install the vendor stats app (it provides the admin, models, and templates), then bridge it to our multi-queue world with a small app `camp.apps.queues`: its `AppConfig.ready()` attaches huey's per-instance stats recorder to the `primary` queue and monkeypatches the dashboard admin's `get_huey()` to return that instance, so the shipped dashboard renders `primary` instead of the unused default instance.
+
+**Tech Stack:** Django, `django-huey` (multi-queue), huey `3.3.0` (`huey.contrib.djhuey.stats`, `huey.contrib.stats`), peewee `4.2.6` (stats storage), pytest / Django `TestCase`, Docker Compose.
+
+## Global Constraints
+
+- huey pinned to exactly `huey==3.3.0`; add `peewee==4.2.6` (undeclared soft dep of the stats contrib).
+- Leave `django-huey==1.3.1` unchanged.
+- Tests inherit Django's `TestCase` and use plain `assert` statements (not `self.assertX`); `pytest.raises` for exceptions.
+- No AI-authorship attribution anywhere in commits or messages.
+- Never `git add -A` — list files explicitly.
+- Don't align `=` signs in field/dict definitions.
+- Run tests via Docker: `docker compose run --rm test pytest <path> -v`. CI runs the bare full suite.
+- New app follows the existing `camp.apps.*` AppConfig pattern (`name = 'camp.apps.queues'`, single `AppConfig` subclass in `apps.py`, auto-discovered).
+- The monkeypatch relies on huey internals (`huey.contrib.djhuey.stats.admin.get_huey`, `huey.contrib.stats.enable_stats`, `huey._stats`); correct for pinned 3.3.0.
+
+---
+
+### Task 1: Upgrade huey to 3.3.0 and add peewee
+
+**Files:**
+- Modify: `requirements/base.txt:40` (the `huey==3.0.1` line) and add a `peewee` pin.
+
+**Interfaces:**
+- Produces (available to later tasks after this lands): the modules `huey.contrib.stats` (`enable_stats(huey, db, **kwargs)`), `huey.contrib.djhuey.stats` (Django app), `huey.contrib.djhuey.stats.apps.stats_database() -> (db, options)`, and `huey.contrib.djhuey.stats.admin.get_huey() -> Huey`.
+
+- [ ] **Step 1: Edit the requirements pin**
+
+In `requirements/base.txt`, change the huey line and add peewee immediately after it:
+
+```
+huey==3.3.0
+peewee==4.2.6
+```
+
+(The original line 40 reads `huey==3.0.1`. `peewee` is not currently present — add it.)
+
+- [ ] **Step 2: Rebuild the image so the new deps install**
+
+Run: `docker compose build web test`
+Expected: build succeeds; `huey==3.3.0` and `peewee==4.2.6` install.
+
+- [ ] **Step 3: Verify the stats modules import and are compatible with peewee 4.x**
+
+Run:
+```bash
+docker compose run --rm web python -c "
+import huey, peewee
+print('huey', huey.__version__, 'peewee', peewee.__version__)
+from huey import MemoryHuey
+from huey.contrib.stats import enable_stats
+from huey.contrib.djhuey.stats.apps import stats_database
+from huey.contrib.djhuey.stats import admin as a
+h = MemoryHuey('compat-check', immediate=False)
+s = enable_stats(h, peewee.SqliteDatabase(':memory:'))
+print('enable_stats ok:', s is not None, 'has _stats:', getattr(h, '_stats', None) is not None)
+print('get_huey present:', callable(a.get_huey))
+"
+```
+Expected output includes: `huey 3.3.0 peewee 4.2.6`, `enable_stats ok: True has _stats: True`, `get_huey present: True`. This empirically confirms huey 3.3.0's stats code works with peewee 4.2.6.
+
+- [ ] **Step 4: Run the full test suite to catch upgrade regressions**
+
+Run: `docker compose run --rm test pytest`
+Expected: PASS (same result as before the bump; the upgrade must not break existing tests). If failures appear, they are upgrade regressions — review the huey 3.0→3.3 changelog (esp. `PriorityRedisHuey` behavior) before proceeding.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add requirements/base.txt
+git commit -m "chore(deps): upgrade huey to 3.3.0, add peewee for stats dashboard"
+```
+
+---
+
+### Task 2: Install the stats app and configure `HUEY_STATS`
+
+**Files:**
+- Modify: `camp/settings/base.py` (add `'huey.contrib.djhuey.stats'` to `INSTALLED_APPS` after `'huey.contrib.djhuey'` at line 88; add a `HUEY_STATS` setting after the `DJANGO_HUEY` block, which ends at line 362).
+- Modify: `camp/settings/test.py` (add a `HUEY_STATS` override pointing stats storage at throwaway in-memory sqlite).
+
+**Interfaces:**
+- Consumes: the stats modules from Task 1.
+- Produces: the vendor stats admin (a "Huey" section) is registered; `settings.HUEY_STATS` exists; under tests, stats storage is ephemeral sqlite (test Postgres untouched).
+
+- [ ] **Step 1: Add the stats app to `INSTALLED_APPS` in `base.py`**
+
+Find (line 88):
+```python
+    'huey.contrib.djhuey',
+```
+Replace with:
+```python
+    'huey.contrib.djhuey',
+    'huey.contrib.djhuey.stats',
+```
+
+- [ ] **Step 2: Add the `HUEY_STATS` setting in `base.py`**
+
+Find the end of the `DJANGO_HUEY` block followed by `MAX_QUEUE_SIZE` (around line 362-364):
+```python
+        },
+    }
+}
+
+MAX_QUEUE_SIZE = int(env('MAX_QUEUE_SIZE', 500))
+```
+Replace with:
+```python
+        },
+    }
+}
+
+HUEY_STATS = {
+    'capture_args': False,
+}
+
+MAX_QUEUE_SIZE = int(env('MAX_QUEUE_SIZE', 500))
+```
+
+(The three-space-then-`}` closing lines belong to the innermost queue dict, the queues dict, and the `DJANGO_HUEY` dict respectively; match them exactly as they appear in the file.)
+
+- [ ] **Step 3: Override `HUEY_STATS` in `test.py` to use ephemeral sqlite**
+
+In `camp/settings/test.py`, after the `DJANGO_HUEY = { ... }` block, add:
+```python
+# Huey stats — keep the test Postgres untouched; the vendor stats app's
+# startup recorder writes its (empty) tables to a throwaway sqlite db instead.
+HUEY_STATS = {
+    'capture_args': False,
+    'database': 'sqlite:///:memory:',
+}
+```
+
+- [ ] **Step 4: Verify settings load and the suite still passes**
+
+Run: `docker compose run --rm test pytest`
+Expected: PASS. (The vendor app's `ready()` now calls `enable_stats(djhuey.HUEY, <sqlite>)` at startup; because `HUEY_STATS['database']` is in-memory sqlite, no test-Postgres tables are created, and the test queues are `immediate=True` so nothing records.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add camp/settings/base.py camp/settings/test.py
+git commit -m "feat(queues): install huey stats dashboard app, add HUEY_STATS config"
+```
+
+---
+
+### Task 3: Create `camp.apps.queues` and wire the dashboard to the primary queue
+
+**Files:**
+- Create: `camp/apps/queues/__init__.py`
+- Create: `camp/apps/queues/apps.py`
+- Create: `camp/apps/queues/stats.py`
+- Create: `camp/apps/queues/tests.py`
+- Modify: `camp/settings/base.py` (add `'camp.apps.queues'` to the `camp.apps.*` block in `INSTALLED_APPS`).
+
+**Interfaces:**
+- Consumes: `django_huey.get_queue(name) -> Huey`; `huey.contrib.stats.enable_stats(huey, db, **options)`; `huey.contrib.djhuey.stats.apps.stats_database() -> (db, options)`; `huey.contrib.djhuey.stats.admin.get_huey` (module attribute to reassign).
+- Produces: `camp.apps.queues.stats.configure_queue_stats(queue_name, queue=None, db=None) -> Huey | None` — attaches the recorder to the resolved queue and points the dashboard admin at it; returns the instance, or `None` when the queue is in immediate mode.
+
+- [ ] **Step 1: Create the package and empty `__init__.py`**
+
+Create `camp/apps/queues/__init__.py` (empty file).
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `camp/apps/queues/tests.py`:
+```python
+import peewee
+from django.test import TestCase
+from huey import MemoryHuey
+from huey.contrib.djhuey.stats import admin as stats_admin
+
+from camp.apps.queues.stats import configure_queue_stats
+
+
+class ConfigureQueueStatsTests(TestCase):
+    def setUp(self):
+        # Restore the dashboard's queue resolver after each test so the
+        # monkeypatch never leaks between tests.
+        original = stats_admin.get_huey
+        self.original_get_huey = original
+        self.addCleanup(setattr, stats_admin, 'get_huey', original)
+
+    def test_wires_recorder_and_dashboard_for_live_queue(self):
+        queue = MemoryHuey('test-live', immediate=False)
+        db = peewee.SqliteDatabase(':memory:')
+
+        result = configure_queue_stats('ignored', queue=queue, db=db)
+
+        assert result is queue
+        assert getattr(queue, '_stats', None) is not None
+        assert stats_admin.get_huey() is queue
+
+    def test_noop_when_queue_is_immediate(self):
+        queue = MemoryHuey('test-immediate', immediate=True)
+        db = peewee.SqliteDatabase(':memory:')
+
+        result = configure_queue_stats('ignored', queue=queue, db=db)
+
+        assert result is None
+        assert getattr(queue, '_stats', None) is None
+        assert stats_admin.get_huey is self.original_get_huey
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `docker compose run --rm test pytest camp/apps/queues/tests.py -v`
+Expected: FAIL with `ModuleNotFoundError` / `ImportError` for `camp.apps.queues.stats` (it doesn't exist yet).
+
+- [ ] **Step 4: Implement `configure_queue_stats`**
+
+Create `camp/apps/queues/stats.py`:
+```python
+def configure_queue_stats(queue_name, queue=None, db=None):
+    """Attach huey's stats recorder to a django-huey queue and point the
+    built-in dashboard admin at that same instance.
+
+    Idempotent per huey instance (``enable_stats`` no-ops if already attached).
+    Returns the wired queue, or ``None`` when the queue runs in immediate mode
+    (tests / local DEBUG), where there is no consumer to monitor.
+    """
+    from django_huey import get_queue
+    from huey.contrib.stats import enable_stats
+    from huey.contrib.djhuey.stats import admin as stats_admin
+    from huey.contrib.djhuey.stats.apps import stats_database
+
+    if queue is None:
+        queue = get_queue(queue_name)
+
+    if queue.immediate:
+        return None
+
+    if db is None:
+        db, options = stats_database()
+    else:
+        options = {}
+
+    enable_stats(queue, db, **options)
+    stats_admin.get_huey = lambda: queue
+    return queue
+```
+
+- [ ] **Step 5: Create the AppConfig that calls it at startup**
+
+Create `camp/apps/queues/apps.py`:
+```python
+from django.apps import AppConfig
+
+
+class QueuesConfig(AppConfig):
+    name = 'camp.apps.queues'
+
+    def ready(self):
+        from .stats import configure_queue_stats
+        configure_queue_stats('primary')
+```
+
+- [ ] **Step 6: Register the app in `INSTALLED_APPS`**
+
+In `camp/settings/base.py`, in the `camp.apps.*` block, add the app. Find:
+```python
+    'camp.apps.qaqc',
+```
+Replace with:
+```python
+    'camp.apps.qaqc',
+    'camp.apps.queues',
+```
+
+- [ ] **Step 7: Run the new tests to verify they pass**
+
+Run: `docker compose run --rm test pytest camp/apps/queues/tests.py -v`
+Expected: PASS (both tests).
+
+- [ ] **Step 8: Run the full suite to confirm nothing else broke**
+
+Run: `docker compose run --rm test pytest`
+Expected: PASS. (App `ready()` runs at startup; the test `primary` queue is `immediate=True`, so `configure_queue_stats('primary')` no-ops and leaves `get_huey` untouched during the suite.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add camp/apps/queues/__init__.py camp/apps/queues/apps.py camp/apps/queues/stats.py camp/apps/queues/tests.py camp/settings/base.py
+git commit -m "feat(queues): point huey stats dashboard at the primary queue"
+```
+
+---
+
+## Manual verification (post-implementation, not automated)
+
+The automated suite runs in immediate mode, so it cannot exercise the live dashboard. Verify against a real consumer once (dev environment):
+
+- [ ] Start the stack: `docker compose --profile web up` (brings up web + `djangohuey` consumers + Redis + Postgres).
+- [ ] Confirm the stats tables were created in the dev Postgres (peewee `create table if not exists` on first `enable_stats`): `docker compose run --rm web python -c "from huey.contrib.djhuey.stats.apps import stats_database; db,_=stats_database(); print(db.get_tables())"` — expect `huey_event` and `huey_inflight` present.
+- [ ] Enqueue a primary-queue task (any existing `db_task` on the primary/default queue) and let the consumer run it.
+- [ ] Log into `/admin/`, open the **Huey** section → **Dashboard**. Confirm: the live tiles (Pending/Scheduled/Results/Running) reflect the `primary` queue, the task appears under recent events / throughput, and the **Events** changelist lists it with `queue = primary_tasks`.
+- [ ] Confirm the flush/revoke controls act on the primary queue (optional; revoke a scheduled task and verify).
+
+If the dashboard shows an empty/default instance instead of primary, `get_huey` was not patched — check that `camp.apps.queues` is in `INSTALLED_APPS` and that the primary queue is not running in immediate mode in that environment.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Dependency upgrade `3.0.1 → 3.3.0` → Task 1. ✅ (plus the peewee soft-dep the spec's `stats_database()`/peewee tables imply → Task 1.)
+- `INSTALLED_APPS` adds `huey.contrib.djhuey.stats` → Task 2 Step 1. ✅
+- `HUEY_STATS` with `capture_args: False` → Task 2 Step 2. ✅
+- Test-suite isolation via sqlite `HUEY_STATS['database']` (revised §5) → Task 2 Step 3. ✅
+- New app `camp.apps.queues` mirroring `djhuey.stats`, with `stats.py` separable from a future `tasks_backend.py` → Task 3 (package layout, `stats.py`). ✅
+- Queue-parametrized `configure_queue_stats(queue_name, queue=None, db=None)` with immediate guard, `enable_stats`, monkeypatch → Task 3 Step 4. ✅
+- `ready()` calls it with `'primary'` → Task 3 Step 5. ✅
+- Unit tests: recorder+patch on live queue, and immediate-mode no-op, with `get_huey` restored per test → Task 3 Step 2. ✅
+- No Procfile change; no Django migration (`managed=False` + peewee DDL) → reflected: no such tasks; manual-verification confirms tables. ✅
+- Manual rendered-dashboard verification → Manual verification section. ✅
+- Out-of-scope items (multi-queue pages, `django.tasks` backend, "registered tasks" list, secondary/summaries) → intentionally not tasked. ✅
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code; every run step shows the exact command and expected result. ✅
+
+**Type consistency:** `configure_queue_stats(queue_name, queue=None, db=None)` is defined in Task 3 Step 4 and consumed identically in the tests (Step 2) and `apps.py` (Step 5). `stats_admin.get_huey` reassigned in Step 4 and asserted in Step 2. `stats_database() -> (db, options)` used as declared. ✅

--- a/docs/superpowers/specs/2026-07-23-huey-primary-dashboard-design.md
+++ b/docs/superpowers/specs/2026-07-23-huey-primary-dashboard-design.md
@@ -160,12 +160,26 @@ HUEY_STATS = {
 
 ### 5. Keep the test suite clean (test.py)
 
-`test.py` inherits `INSTALLED_APPS` from base via `from .base import *`. Remove
-`huey.contrib.djhuey.stats` from the inherited list in `test.py` so the
-third-party app's `ready()` never connects to or creates tables in the test
-database. Our own `camp.apps.queues.ready()` already no-ops under tests
-because the test `DJANGO_HUEY` queues run `immediate=True`, but dropping the
-vendor app removes the other path to the test DB as well.
+The stats app **stays installed** under tests — its models are Django models, so
+`configure_queue_stats` importing `huey.contrib.djhuey.stats.admin` (to patch
+`get_huey`) requires the app in `INSTALLED_APPS`, otherwise it raises
+`RuntimeError: Model ... doesn't declare an explicit app_label`. Removing the app
+would make the wiring function un-importable and therefore un-testable.
+
+Instead, keep the test Postgres untouched by pointing stats storage at throwaway
+in-memory sqlite in `test.py`:
+
+```python
+HUEY_STATS = {'capture_args': False, 'database': 'sqlite:///:memory:'}
+```
+
+With this, the vendor app's own startup `enable_stats(djhuey.HUEY, db)` creates
+its (empty) tables in an ephemeral sqlite db on a separate peewee connection,
+never in the test Postgres. Our `camp.apps.queues.ready()` still no-ops under
+tests because the test `DJANGO_HUEY` queues run `immediate=True`. The stats
+models are `managed=False`, so Django's test-DB setup never creates them either.
+The unit test injects its *own* in-memory sqlite db into `configure_queue_stats`,
+so it depends on none of this.
 
 ## Out of scope (follow-ups)
 
@@ -190,9 +204,9 @@ vendor app removes the other path to the test DB as well.
 ## Testing
 
 The wiring function is tested hermetically — it accepts injected `queue` and
-`db` arguments, so the tests never depend on the third-party stats app being in
-`INSTALLED_APPS` (it is removed in `test.py`) and never touch the default test
-database.
+`db` arguments, so the tests never touch the default test database (they use an
+in-memory sqlite peewee db) and don't rely on the vendor app's own startup
+recorder.
 
 - **Unit** (`camp/apps/queues/tests.py`): call `configure_queue_stats(...)`
   with a **non-immediate** `MemoryHuey` and an in-memory peewee
@@ -205,8 +219,9 @@ Each test restores `huey.contrib.djhuey.stats.admin.get_huey` to its original
 value afterward so the monkeypatch does not leak across tests.
 
 A rendered-dashboard check (staff `GET` → `200`) is **not** part of the
-automated suite — the stats app is intentionally absent under tests. It is
-covered instead by the manual verification step below.
+automated suite — under tests the queues run `immediate=True`, so `get_huey` is
+never patched to a real instance and the live panel has nothing meaningful to
+render. It is covered instead by the manual verification step below.
 
 Tests follow project conventions: inherit from Django's `TestCase`, use plain
 `assert` statements, and use fixtures where needed.

--- a/docs/superpowers/specs/2026-07-23-huey-primary-dashboard-design.md
+++ b/docs/superpowers/specs/2026-07-23-huey-primary-dashboard-design.md
@@ -12,9 +12,23 @@ log, and flush/revoke controls — using huey's built-in
 `huey.contrib.djhuey.stats` app, without disturbing the existing multi-queue
 `DJANGO_HUEY` configuration or the `djangohuey` consumer model.
 
-Only the **primary** queue is in scope. The secondary queue is low-traffic and
-the summaries queue is monitored by other means; both are explicitly out of
-scope here.
+Only the **primary** queue is wired in this cut. The secondary queue is
+low-traffic and the summaries queue is monitored by other means; both are
+explicitly out of scope here.
+
+### Wider intent (why the shape matters)
+
+This is deliberately built as **bridge #1** over a known structural gap: huey's
+Django integration (`huey.contrib.djhuey`) is single-instance by design, so its
+new dashboard doesn't compose with the multi-queue `django-huey` we depend on.
+The longer-term aim is a queue-aware observability layer — a
+`/admin/queues/<name>/` surface across all queues — that could eventually be
+extracted as an add-on to **`django-huey`** (the incumbent multi-queue package),
+not a fork of `djhuey` and not a change to huey core. See **Strategic context**
+at the end. Concretely, that means: the code lives in a real app
+(`camp.apps.queues`) shaped to mirror `djhuey.stats` for portability, and the
+wiring is written **queue-parametrized** (takes a queue name; this cut passes
+`'primary'`) rather than hardcoding `primary` throughout.
 
 ## Background / constraints
 
@@ -49,11 +63,22 @@ dashboard must therefore point at the **same object** the consumer uses:
 ## Decisions
 
 - **Upgrade huey `3.0.1 → 3.3.0`** (current latest; the dashboard requires ≥ 3.2.1).
-- **Point the dashboard at primary by monkeypatching** `get_huey` rather than
-  subclassing/re-registering the admin. Both admin methods reference the
-  module-level `get_huey`, so reassigning that one attribute covers the whole
+- **Point the dashboard at the target queue by monkeypatching** `get_huey`
+  rather than subclassing/re-registering the admin. Both admin methods reference
+  the module-level `get_huey`, so reassigning that one attribute covers the whole
   dashboard, and we avoid copying ~40 lines of huey-internal method bodies that
   would need to be kept in sync across upgrades.
+- **House it in a new app `camp.apps.queues`**, structured to mirror
+  `huey.contrib.djhuey.stats` (an `AppConfig.ready()` that calls `enable_stats`),
+  so a later extraction into a `django-huey` add-on is close to a copy rather
+  than a redesign. The stats/dashboard concern is kept in its own submodule so a
+  future `django.tasks` multi-queue backend can live beside it as a separate,
+  independently-extractable module.
+- **Scope note on the monkeypatch:** it points the *one* shipped dashboard at
+  *one* queue. It is correct for this single-page cut but is **not** the
+  mechanism for the eventual multi-page `/admin/queues/<name>/` surface — that
+  needs queue-aware views (see Out of scope), because three monkeypatches would
+  fight over the single `get_huey` and the shipped templates' global URL names.
 
 ## Changes
 
@@ -77,29 +102,39 @@ default) `djhuey.HUEY` instance. This is harmless — that instance never runs
 tasks — and has the useful side effect of creating the peewee tables. No Django
 migration is required (peewee issues `create table if not exists`).
 
-### 3. New app: `camp.apps.taskstats`
+### 3. New app: `camp.apps.queues`
 
-A minimal app whose only job is an `AppConfig.ready()` hook (the glue cannot live
-inside the third-party package). Structure: `apps.py`, `__init__.py`, `tests.py`.
-Add `camp.apps.taskstats` to `INSTALLED_APPS`.
+A small app whose job (for now) is an `AppConfig.ready()` hook that wires the
+dashboard to a queue — the glue cannot live inside the third-party package. Add
+`camp.apps.queues` to `INSTALLED_APPS`. Layout, shaped to mirror
+`djhuey.stats` and to keep concerns separable:
 
-The wiring logic lives in a small, testable function — e.g.
-`configure_primary_stats(queue=None, db=None)`, where both arguments default to
-the production values (`get_queue('primary')` and `stats_database()`) but can be
-injected in tests. Called from `ready()` with no arguments:
+```
+camp/apps/queues/
+    __init__.py
+    apps.py        # QueuesConfig.ready() -> configure_queue_stats('primary')
+    stats.py       # configure_queue_stats(...) — the dashboard bridge
+    tests.py
+    # (future) tasks_backend.py — multi-queue django.tasks backend
+```
 
-1. Resolve the primary instance: `queue = queue or get_queue('primary')` (via
+The wiring lives in a small, testable, **queue-parametrized** function in
+`stats.py` — e.g. `configure_queue_stats(queue_name, queue=None, db=None)`.
+`queue`/`db` default to the production values but can be injected in tests.
+`ready()` calls `configure_queue_stats('primary')`. Steps:
+
+1. Resolve the instance: `queue = queue or get_queue(queue_name)` (via
    `django_huey.get_queue`).
 2. **Guard:** if `queue.immediate` is true, return immediately — there is no
    consumer, so a live dashboard is meaningless (covers tests and local DEBUG).
 3. Obtain the stats DB if not injected: `db, options = stats_database()` from
    `huey.contrib.djhuey.stats.apps`.
-4. `enable_stats(queue, db, **options)` — attaches the recorder to the primary
-   instance (idempotent), so execution signals are recorded and `queue._stats`
-   is populated.
+4. `enable_stats(queue, db, **options)` — attaches the recorder to that instance
+   (idempotent), so execution signals are recorded and `queue._stats` is
+   populated.
 5. Monkeypatch: `huey.contrib.djhuey.stats.admin.get_huey = lambda: queue` — the
    Dashboard page's live counts, charts, per-task stats, and flush/revoke
-   controls now all target primary.
+   controls now all target that queue.
 
 Note the guard means `ready()` is a no-op in the normal test run; the function
 is exercised directly with injected arguments (see Testing).
@@ -108,6 +143,11 @@ is exercised directly with injected arguments (see Testing).
 the `djangohuey` consumers (management commands load apps first) and the web
 server — so the recorder is attached wherever tasks execute, and the monkeypatch
 is applied wherever the admin is served.
+
+The function is queue-parametrized so the eventual multi-queue work reuses it to
+register recorders per queue; the single shipped admin still shows one queue via
+the monkeypatch (that's this cut), and the multi-page surface is a later,
+separate step (Out of scope).
 
 ### 4. `HUEY_STATS` setting (base.py)
 
@@ -123,12 +163,24 @@ HUEY_STATS = {
 `test.py` inherits `INSTALLED_APPS` from base via `from .base import *`. Remove
 `huey.contrib.djhuey.stats` from the inherited list in `test.py` so the
 third-party app's `ready()` never connects to or creates tables in the test
-database. Our own `camp.apps.taskstats.ready()` already no-ops under tests
+database. Our own `camp.apps.queues.ready()` already no-ops under tests
 because the test `DJANGO_HUEY` queues run `immediate=True`, but dropping the
 vendor app removes the other path to the test DB as well.
 
 ## Out of scope (follow-ups)
 
+- **Multi-queue dashboard** (`/admin/queues/<name>/`). This cut points the one
+  shipped admin at `primary` via the monkeypatch. Covering all queues means:
+  (a) register recorders on every queue (`configure_queue_stats(name)` per queue,
+  into the one shared stats DB — events are already `queue`-tagged), and
+  (b) build **queue-aware views** on huey's public `live_counts()` /
+  `dashboard_context()` / `HueyStats` helpers. It does **not** mean calling the
+  wiring three times against the shipped admin — that would collide on the single
+  `get_huey` and the shipped templates' global URL names. This is the seed of the
+  extractable `django-huey` add-on.
+- **`django.tasks` multi-queue backend** — a `HueyBackend` variant routing
+  `queue_name → get_queue(name)`; the main design problem is namespacing result
+  ids per queue. Separate module (`tasks_backend.py`), separate effort.
 - **"Registered tasks" list** in the dashboard will be sparse in the web
   process, because `django_huey` autodiscovers `tasks.py` modules only in the
   consumer. Populating it means importing the primary queue's task modules in
@@ -142,7 +194,7 @@ The wiring function is tested hermetically — it accepts injected `queue` and
 `INSTALLED_APPS` (it is removed in `test.py`) and never touch the default test
 database.
 
-- **Unit** (`camp/apps/taskstats/tests.py`): call `configure_primary_stats(...)`
+- **Unit** (`camp/apps/queues/tests.py`): call `configure_queue_stats(...)`
   with a **non-immediate** `MemoryHuey` and an in-memory peewee
   `SqliteDatabase`, then assert (a) `queue._stats` is set after the call and
   (b) `huey.contrib.djhuey.stats.admin.get_huey()` returns that instance.
@@ -168,6 +220,50 @@ Tests follow project conventions: inherit from Django's `TestCase`, use plain
 - **Verify against a real consumer**, not just immediate-mode tests: run
   `djangohuey --queue primary`, enqueue a task, and confirm events land and the
   dashboard renders live data.
+
+## Strategic context
+
+Recorded so future work has the reasoning, not just the code.
+
+- **Why this exists as a bridge.** huey's Django layer (`huey.contrib.djhuey`)
+  is single-instance *by design*; the maintainer treats single-queue-in-Django
+  as a deliberate choice (huey issue #838) and steers users toward one queue +
+  priorities. We need multiple queues for genuine worker isolation (see the
+  queue-topology note below), so we run `django-huey`, and every new huey
+  Django-layer feature — this dashboard, later the `django.tasks` backend — has
+  to be bridged by hand. This is **bridge #1**.
+
+- **Queue topology is correct, keep it.** The three queues buy worker isolation,
+  which task priorities cannot provide (priority is dequeue ordering, not
+  capacity reservation or preemption). `primary` = latency-sensitive ingest +
+  scheduler; `secondary` = on-demand heavy bulk imports that must never starve
+  `primary`; `summaries` = long, memory-tuned rollups. huey's own docs list
+  "isolation … must never starve critical tasks of workers" as the reason to use
+  separate queues. Do **not** collapse queues to simplify monitoring — that is
+  the tail wagging the dog.
+
+- **Tripwire — when to reconsider the whole stack.** The migration trigger is not
+  "we use `django-huey`." It is the **number of hand-built bridges** we maintain
+  to keep `django-huey` composing with modern huey, and whether each huey upgrade
+  threatens them. One or two (this dashboard, maybe a rate-limit helper): fine,
+  stay. If we reach bridge #3–#4 and huey bumps become tense regression checks on
+  our monkeypatches, we have structurally outgrown the arrangement — and at that
+  point the principled move is **Celery** (native multi-queue routing) or
+  **Dramatiq**, chosen for the *isolation/routing* need, not for ecosystem size.
+
+- **Upstream posture (if we choose to give back).** Ranked: (1) build here first
+  — the deliverable and the proving ground, no external commitment; (2) if giving
+  back, contribute the two add-on modules (stats/dashboard + `django.tasks`
+  backend) to **`django-huey`**, the incumbent — additive features to a
+  maintained project, no ecosystem fragmentation; (3) a standalone package only
+  as a fallback if `django-huey` won't take them. A **new unified djhuey/django-
+  huey rewrite is explicitly rejected** — `django-huey` already covers multi-queue
+  config, per-queue consumers, decorators, signals, and DB-connection handling;
+  the only real gaps are those two modules. A separate, minimal upstream nicety
+  worth floating to huey *issue-first* (not as a surprise PR, and with low
+  expectations given #838): make `djhuey.stats`' instance resolution configurable
+  (e.g. honor `HUEY_STATS['huey']`), which turns this cut's monkeypatch into a
+  supported setting and helps single-queue users too.
 
 ## Risks
 

--- a/docs/superpowers/specs/2026-07-23-huey-primary-dashboard-design.md
+++ b/docs/superpowers/specs/2026-07-23-huey-primary-dashboard-design.md
@@ -1,0 +1,179 @@
+# Huey primary-queue admin dashboard — design
+
+**Date:** 2026-07-23
+**Status:** Approved, ready for implementation planning
+
+## Goal
+
+Add a single Django-admin page that shows live task statistics for the
+**primary** `django_huey` queue — live queue depths (pending/scheduled/results),
+running tasks, a throughput chart, per-task timing/error rates, a recent-event
+log, and flush/revoke controls — using huey's built-in
+`huey.contrib.djhuey.stats` app, without disturbing the existing multi-queue
+`DJANGO_HUEY` configuration or the `djangohuey` consumer model.
+
+Only the **primary** queue is in scope. The secondary queue is low-traffic and
+the summaries queue is monitored by other means; both are explicitly out of
+scope here.
+
+## Background / constraints
+
+- The project runs multiple queues via **`django-huey`** (`DJANGO_HUEY` setting +
+  `manage.py djangohuey --queue <name>`), which builds three independent Huey
+  instances: `primary`, `secondary`, `summaries`. `settings.HUEY` is **not** set.
+- huey's built-in dashboard (`huey.contrib.djhuey.stats`, added in huey **3.2.1**)
+  is wired to the single-instance `huey.contrib.djhuey` integration. Its admin
+  resolves the queue through a module-level function
+  `huey.contrib.djhuey.stats.admin.get_huey()`, which returns
+  `huey.contrib.djhuey.HUEY` (the `settings.HUEY` instance). It is used in
+  exactly two methods: `HueyDashboardAdmin._context()` and `.action_view()`.
+- The underlying engine (`huey.contrib.stats`) is per-instance and queue-tagged:
+  `enable_stats(huey, db)` attaches a recorder to one Huey instance (idempotent
+  per instance, stashes the recorder on `huey._stats`), and events are written to
+  peewee tables `huey_event` / `huey_inflight` with an indexed `queue` column.
+  `live_counts(huey)` and `dashboard_context(huey, stats, ...)` both take the
+  instance as an argument — nothing is a hard singleton at the data layer.
+- The currently installed huey is **3.0.1**, which predates the dashboard.
+
+### Why not simply set `settings.HUEY` to mirror primary
+
+Recording happens on the instance whose consumer executes the task — i.e.
+`django_huey`'s primary instance (run by `djangohuey --queue primary`). If
+`settings.HUEY` were a separate instance mirroring primary's storage, the
+dashboard's `_stats` lookup and the recorder would sit on **different objects**:
+live counts would work (same Redis) but the throughput/per-task panels would be
+empty because no recorder receives the consumer's signals. The recorder and the
+dashboard must therefore point at the **same object** the consumer uses:
+`get_queue('primary')`.
+
+## Decisions
+
+- **Upgrade huey `3.0.1 → 3.3.0`** (current latest; the dashboard requires ≥ 3.2.1).
+- **Point the dashboard at primary by monkeypatching** `get_huey` rather than
+  subclassing/re-registering the admin. Both admin methods reference the
+  module-level `get_huey`, so reassigning that one attribute covers the whole
+  dashboard, and we avoid copying ~40 lines of huey-internal method bodies that
+  would need to be kept in sync across upgrades.
+
+## Changes
+
+### 1. Dependency
+
+Bump `huey` from `3.0.1` to `3.3.0` in the requirements file.
+
+### 2. `INSTALLED_APPS` (base.py)
+
+Add `huey.contrib.djhuey.stats` (alongside the existing
+`huey.contrib.djhuey`). This provides:
+
+- the admin registrations (`HueyEventAdmin`, `HueyDashboardAdmin`),
+- the `managed=False` Django models mapping to the `huey_event` /
+  `huey_inflight` tables (so the **Events** changelist reads them through the
+  ORM), and
+- the dashboard templates.
+
+The app's own `ready()` calls `enable_stats(djhuey.HUEY, db)` on the (unused,
+default) `djhuey.HUEY` instance. This is harmless — that instance never runs
+tasks — and has the useful side effect of creating the peewee tables. No Django
+migration is required (peewee issues `create table if not exists`).
+
+### 3. New app: `camp.apps.taskstats`
+
+A minimal app whose only job is an `AppConfig.ready()` hook (the glue cannot live
+inside the third-party package). Structure: `apps.py`, `__init__.py`, `tests.py`.
+Add `camp.apps.taskstats` to `INSTALLED_APPS`.
+
+The wiring logic lives in a small, testable function — e.g.
+`configure_primary_stats(queue=None, db=None)`, where both arguments default to
+the production values (`get_queue('primary')` and `stats_database()`) but can be
+injected in tests. Called from `ready()` with no arguments:
+
+1. Resolve the primary instance: `queue = queue or get_queue('primary')` (via
+   `django_huey.get_queue`).
+2. **Guard:** if `queue.immediate` is true, return immediately — there is no
+   consumer, so a live dashboard is meaningless (covers tests and local DEBUG).
+3. Obtain the stats DB if not injected: `db, options = stats_database()` from
+   `huey.contrib.djhuey.stats.apps`.
+4. `enable_stats(queue, db, **options)` — attaches the recorder to the primary
+   instance (idempotent), so execution signals are recorded and `queue._stats`
+   is populated.
+5. Monkeypatch: `huey.contrib.djhuey.stats.admin.get_huey = lambda: queue` — the
+   Dashboard page's live counts, charts, per-task stats, and flush/revoke
+   controls now all target primary.
+
+Note the guard means `ready()` is a no-op in the normal test run; the function
+is exercised directly with injected arguments (see Testing).
+
+`ready()` runs in every process that loads the Django app registry — including
+the `djangohuey` consumers (management commands load apps first) and the web
+server — so the recorder is attached wherever tasks execute, and the monkeypatch
+is applied wherever the admin is served.
+
+### 4. `HUEY_STATS` setting (base.py)
+
+```python
+HUEY_STATS = {
+    'capture_args': False,   # do not persist task arguments
+    # retention_hours / max_events left at defaults; stored in DATABASES['default']
+}
+```
+
+### 5. Keep the test suite clean (test.py)
+
+`test.py` inherits `INSTALLED_APPS` from base via `from .base import *`. Remove
+`huey.contrib.djhuey.stats` from the inherited list in `test.py` so the
+third-party app's `ready()` never connects to or creates tables in the test
+database. Our own `camp.apps.taskstats.ready()` already no-ops under tests
+because the test `DJANGO_HUEY` queues run `immediate=True`, but dropping the
+vendor app removes the other path to the test DB as well.
+
+## Out of scope (follow-ups)
+
+- **"Registered tasks" list** in the dashboard will be sparse in the web
+  process, because `django_huey` autodiscovers `tasks.py` modules only in the
+  consumer. Populating it means importing the primary queue's task modules in
+  `ready()`. Deferred; throughput/event data comes from the DB regardless.
+- **secondary / summaries** queues — handled by other means.
+
+## Testing
+
+The wiring function is tested hermetically — it accepts injected `queue` and
+`db` arguments, so the tests never depend on the third-party stats app being in
+`INSTALLED_APPS` (it is removed in `test.py`) and never touch the default test
+database.
+
+- **Unit** (`camp/apps/taskstats/tests.py`): call `configure_primary_stats(...)`
+  with a **non-immediate** `MemoryHuey` and an in-memory peewee
+  `SqliteDatabase`, then assert (a) `queue._stats` is set after the call and
+  (b) `huey.contrib.djhuey.stats.admin.get_huey()` returns that instance.
+- **Immediate-mode guard:** call it with an `immediate=True` instance and assert
+  `get_huey` is left unpatched and `queue._stats` is unset.
+
+Each test restores `huey.contrib.djhuey.stats.admin.get_huey` to its original
+value afterward so the monkeypatch does not leak across tests.
+
+A rendered-dashboard check (staff `GET` → `200`) is **not** part of the
+automated suite — the stats app is intentionally absent under tests. It is
+covered instead by the manual verification step below.
+
+Tests follow project conventions: inherit from Django's `TestCase`, use plain
+`assert` statements, and use fixtures where needed.
+
+## Ops / rollout notes
+
+- **No Procfile change.** The recorder attaches in-process via `ready()`; the
+  existing `djangohuey --queue primary` worker/scheduler pick it up automatically.
+- **No Django migration.** The stats tables are created by peewee on first
+  `enable_stats`.
+- **Verify against a real consumer**, not just immediate-mode tests: run
+  `djangohuey --queue primary`, enqueue a task, and confirm events land and the
+  dashboard renders live data.
+
+## Risks
+
+- Relies on huey internals not covered by its public API: the
+  `stats.admin.get_huey` attribute, `enable_stats`, `huey._stats`, and the
+  dashboard template URL names. Pinned to huey 3.3.0. A rename on a future bump
+  would fail loudly at `ready()` (AttributeError), which is easy to detect.
+- The huey `3.0.1 → 3.3.0` bump is the largest change to validate; review the
+  changelog for behavior affecting `PriorityRedisHuey` and run the full suite.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -37,7 +37,8 @@ geopandas==1.1.3
 geopy==2.4.1
 gunicorn==26.0.0
 hiredis==3.4.0
-huey==3.0.1
+huey==3.3.0
+peewee==4.2.6
 invoke==3.0.3
 jsonschema==4.26.0
 libsass==0.23.0


### PR DESCRIPTION
## Summary

Adds a built-in Huey stats dashboard for the **primary** queue, wired into the Django admin. Huey ships its own admin dashboard (`huey.contrib.djhuey.stats`, added in 3.2.1), but its admin resolves the queue from the single `settings.HUEY` instance — which this project never sets, since we run multiple queues via `django-huey`. This branch bridges that gap for the primary queue and leaves the three-queue `django-huey` setup untouched.

Built queue-parametrized as the seed of a future multi-queue `/admin/queues/<name>/` surface.

## Changes

- **Deps:** upgrade `huey` 3.0.1 → 3.3.0; add `peewee==4.2.6` (undeclared soft-dep of the stats contrib).
- **New app `camp.apps.queues`:** on startup, attaches huey's per-instance stats recorder to the primary `django-huey` queue and points the dashboard admin's `get_huey()` at that same instance. Wiring is wrapped in try/except so a future huey internals rename degrades gracefully (logged + swallowed) instead of crashing every web/worker process. No-ops in immediate mode (tests).
- **Admin:** the primary queue name in the admin index Queues sidebar now links to the dashboard.
- **Bounded retention:** `HUEY_STATS` set to `retention_hours=24`, `max_events=250_000`, `capture_args=False`. The primary queue's per-monitor fan-out (one `process_data` per sensor, every minute) is high-volume, so the default `max_events=2000` would hold only seconds of history. The stats contrib self-prunes on both bounds, so the tables stay capped (~60–100MB in the app Postgres DB) — no cron or manual flush needed.

## Notes

- Stats tables (`huey_event`, `huey_inflight`) are `managed=False` and auto-created at startup — no migration.
- The `secondary` and `summaries` queues are intentionally out of scope (secondary is rarely on; summaries handled elsewhere).
- Design spec and implementation plan included under `docs/superpowers/`.

## Testing

- `camp/apps/queues/tests.py`: recorder + dashboard wiring for a live queue, immediate-mode no-op, and graceful-degradation-on-error.
- Full suite: **694 passed**.
