### PR TITLE
fix(calibrations): fall back to healthy PM2.5 channel when the other fails

### DIFF
--- a/camp/apps/calibrations/core/processors/pm25/lcs.py
+++ b/camp/apps/calibrations/core/processors/pm25/lcs.py
@@ -42,28 +42,17 @@ class PM25_LCS_Correction(BaseProcessor):
                 return False
         return True
 
-    def process(self):
-        if (self.entry.value is None
-            or self.entry.value < -15
-            or self.entry.value > 3000
-        ):
-            # Clearly invalid
-            return
-
-        if self.is_repeated():
-            # Filter out repeated sequences
-            return
-
-        cleaned_value = self.compute_ab_adjusted_value()
-        cleaned_value = max(cleaned_value, 0)
-        return self.build_entry(
-            value=cleaned_value,
-            sensor='', # At this point, A and B are effectively merged.
+    def out_of_bounds(self, value):
+        return (
+            value is None
+            or value < -15
+            or value > 3000
         )
 
-    def is_repeated(self, max_repeat=5) -> bool:
+    def is_repeated(self, entry, max_repeat=5) -> bool:
         '''
-        Checks whether the given entry is part of a sequence of repeated values.
+        Checks whether the given entry's value is part of a sequence of
+        repeated values on its own sensor channel.
 
         A value is considered repeated if it appears at least `max_repeat`
         consecutive times across the same sensor (looking both backward and forward).
@@ -75,13 +64,13 @@ class PM25_LCS_Correction(BaseProcessor):
         Returns:
             bool: True if the value is part of a repeated sequence, False otherwise.
         '''
-        value = self.entry.value
+        value = entry.value
 
-        prev_values = list(self.entry
+        prev_values = list(entry
             .get_previous_entries()
             .values_list('value', flat=True)[:max_repeat]
         )
-        next_values = list(self.entry
+        next_values = list(entry
             .get_next_entries()
             .values_list('value', flat=True)[:max_repeat]
         )
@@ -92,21 +81,48 @@ class PM25_LCS_Correction(BaseProcessor):
 
         return repeat_count > max_repeat
 
+    def is_healthy(self, entry) -> bool:
+        '''
+        A channel is healthy if it has a reading, that reading is in
+        bounds, and it isn't flatlined/repeating.
+        '''
+        return (
+            entry is not None
+            and not self.out_of_bounds(entry.value)
+            and not self.is_repeated(entry)
+        )
+
+    def process(self):
+        entry_ok = self.is_healthy(self.entry)
+        sibling_ok = self.is_healthy(self.sibling)
+
+        if entry_ok and sibling_ok:
+            # Both channels look good, blend them.
+            value = self.compute_ab_adjusted_value()
+        elif entry_ok:
+            # Only this channel is healthy, use it alone.
+            value = self.entry.value
+        elif sibling_ok:
+            # Only the sibling channel is healthy, fall back to it.
+            value = self.sibling.value
+        else:
+            # Neither channel is usable.
+            return
+
+        value = max(value, 0)
+        return self.build_entry(
+            value=value,
+            sensor='', # At this point, A and B are effectively merged.
+        )
+
     def compute_ab_adjusted_value(self) -> Decimal:
         '''
-        Computes cleaned value using a/b sensor logic.
+        Blends the A and B sensor values. Only called once both channels
+        have independently passed their own health check.
 
-        - If both A and B exist:
-            - use average if variance_pct ≤ 10
-            - use min(a, b) if variance_pct > 10
-        - If only one exists, use that value
-        - If neither, return self.entry.value
+        - use average if variance_pct ≤ 10
+        - use min(a, b) if variance_pct > 10
         '''
-        current_value = self.entry.value
-
-        if not self.sibling:
-            return current_value
-
         a = self.entry.value
         b = self.sibling.value
 

--- a/camp/apps/calibrations/tests/test_processors.py
+++ b/camp/apps/calibrations/tests/test_processors.py
@@ -193,6 +193,124 @@ class ProcessorTests(TestCase):
         expected = (a_entry.value + b_entry.value) / 2
         assert cleaned.value == expected
 
+    def test_pm25_lcs_correction_falls_back_when_channel_a_flatlined(self):
+        # Channel A is dead, stuck at 0.00. Channel B is healthy and varying.
+        # Correction should discard A and fall back to B instead of
+        # discarding the reading entirely.
+        base_time = timezone.now() - timedelta(minutes=20)
+        timestamps = [base_time + timedelta(minutes=2 * i) for i in range(11)]
+        b_values = [5.3, 6.4, 6.6, 5.3, 5.6, 7.5, 6.4, 6.4, 6.3, 6.4, 5.9]
+
+        a_entries = []
+        b_entries = []
+        for ts, bval in zip(timestamps, b_values):
+            a = entry_models.PM25.objects.create(
+                monitor=self.monitor,
+                timestamp=ts,
+                sensor='a',
+                value=Decimal('0.00'),
+                position=self.monitor.position,
+                location=self.monitor.location,
+                stage=entry_models.PM25.Stage.RAW,
+            )
+            b = entry_models.PM25.objects.create(
+                monitor=self.monitor,
+                timestamp=ts,
+                sensor='b',
+                value=Decimal(str(bval)),
+                position=self.monitor.position,
+                location=self.monitor.location,
+                stage=entry_models.PM25.Stage.RAW,
+            )
+            a.refresh_from_db()
+            b.refresh_from_db()
+            a_entries.append(a)
+            b_entries.append(b)
+
+        mid = len(a_entries) // 2
+        cleaner = processors.PM25_LCS_Correction(a_entries[mid])
+        cleaned = cleaner.run()
+
+        assert cleaned is not None
+        assert cleaned.value == b_entries[mid].value
+
+    def test_pm25_lcs_correction_falls_back_when_channel_a_out_of_bounds(self):
+        # Channel A is pegged above the valid range. Channel B is healthy.
+        # Correction should discard A and fall back to B.
+        base_time = timezone.now() - timedelta(minutes=20)
+        timestamps = [base_time + timedelta(minutes=2 * i) for i in range(11)]
+        a_values = [3108.80, 3111.40, 3108.20, 3107.20, 3107.70, 3099.50, 3100.80, 3104.00, 3106.70, 3105.40, 3110.10]
+        b_values = [4.5, 4.3, 4.8, 5.3, 4.3, 4.8, 4.6, 4.7, 4.2, 5.0, 4.9]
+
+        a_entries = []
+        b_entries = []
+        for ts, aval, bval in zip(timestamps, a_values, b_values):
+            a = entry_models.PM25.objects.create(
+                monitor=self.monitor,
+                timestamp=ts,
+                sensor='a',
+                value=Decimal(str(aval)),
+                position=self.monitor.position,
+                location=self.monitor.location,
+                stage=entry_models.PM25.Stage.RAW,
+            )
+            b = entry_models.PM25.objects.create(
+                monitor=self.monitor,
+                timestamp=ts,
+                sensor='b',
+                value=Decimal(str(bval)),
+                position=self.monitor.position,
+                location=self.monitor.location,
+                stage=entry_models.PM25.Stage.RAW,
+            )
+            a.refresh_from_db()
+            b.refresh_from_db()
+            a_entries.append(a)
+            b_entries.append(b)
+
+        mid = len(a_entries) // 2
+        cleaner = processors.PM25_LCS_Correction(a_entries[mid])
+        cleaned = cleaner.run()
+
+        assert cleaned is not None
+        assert cleaned.value == b_entries[mid].value
+
+    def test_pm25_lcs_correction_discards_when_both_channels_bad(self):
+        # Both channels are unusable (A out of bounds, B flatlined). The
+        # reading should still be discarded entirely.
+        base_time = timezone.now() - timedelta(minutes=20)
+        timestamps = [base_time + timedelta(minutes=2 * i) for i in range(11)]
+
+        a_entries = []
+        for ts in timestamps:
+            a = entry_models.PM25.objects.create(
+                monitor=self.monitor,
+                timestamp=ts,
+                sensor='a',
+                value=Decimal('3500.00'),
+                position=self.monitor.position,
+                location=self.monitor.location,
+                stage=entry_models.PM25.Stage.RAW,
+            )
+            b = entry_models.PM25.objects.create(
+                monitor=self.monitor,
+                timestamp=ts,
+                sensor='b',
+                value=Decimal('0.00'),
+                position=self.monitor.position,
+                location=self.monitor.location,
+                stage=entry_models.PM25.Stage.RAW,
+            )
+            a.refresh_from_db()
+            b.refresh_from_db()
+            a_entries.append(a)
+
+        mid = len(a_entries) // 2
+        cleaner = processors.PM25_LCS_Correction(a_entries[mid])
+        cleaned = cleaner.run()
+
+        assert cleaned is None
+
     def test_pm25_epa_oct2021(self):
         now = timezone.now()
 


### PR DESCRIPTION
## Summary
- `PM25_LCS_Correction` only ever validated channel A's own raw value (bounds + repeat/flatline check) before blending A/B, so a permanently bad A channel discarded every reading forever — even when B was perfectly healthy.
- Both channels are now checked independently (`is_healthy`); correction blends them when both are good, falls back to whichever one is usable when only one is, and only discards the reading when both are bad.
- Found via two real PurpleAir monitors (Stadium, Stockton Climate Sensor 3) whose PM2.5 pipeline had been silently stuck at the `cleaned`/`corrected` stage for months (channel A dead — flatlined at 0.00 on one, pegged >3000 on the other) despite the monitors otherwise reporting fine.

## Test plan
- [x] `docker compose run --rm test pytest camp/apps/calibrations/` — 39 passed
- [x] New regression tests cover: channel A flatlined + B healthy → falls back to B; channel A out-of-bounds + B healthy → falls back to B; both channels bad → still discarded
- [x] Existing high/low-variance blend tests unchanged and still pass

## Follow-up (not in this PR)
- This only affects entries processed going forward. Stadium (stuck since 2025-07-24) and Stockton (stuck since 2025-10-13) have a real gap in CORRECTED/CLEANED/CALIBRATED history that would need a separate reprocessing pass over their existing RAW entries to backfill.